### PR TITLE
fix: use ANTHROPIC_AUTH_TOKEN to prevent login prompt

### DIFF
--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -171,8 +171,7 @@ function launchServer(
         env: {
           ...cleanEnv,
           ANTHROPIC_BASE_URL: `http://localhost:${port}/api`,
-          ANTHROPIC_API_KEY:
-            'sk-ant-api03-brcc-proxy-00000000000000000000000000000000000000000000-00000000000000',
+          ANTHROPIC_AUTH_TOKEN: 'x402-proxy-handles-auth',
           ANTHROPIC_DEFAULT_SONNET_MODEL: sonnetModel,
           ANTHROPIC_DEFAULT_OPUS_MODEL: opusModel,
           ANTHROPIC_DEFAULT_HAIKU_MODEL: haikuModel,


### PR DESCRIPTION
## Summary

- Replace `ANTHROPIC_API_KEY` with `ANTHROPIC_AUTH_TOKEN` when spawning Claude Code in `start.ts`
- Claude Code checks `ANTHROPIC_AUTH_TOKEN` to determine if the user is authenticated, not `ANTHROPIC_API_KEY`
- Without this, Claude Code ignores the API key and shows a login prompt even though the proxy is running correctly

## Problem

Running `brcc start --model <model>` would spawn Claude Code but it would prompt for login, even though:
- The proxy was running on the correct port
- Curl tests confirmed the endpoint worked

This happened because the previous code set `ANTHROPIC_API_KEY` which Claude Code ignores for auth detection.

## Fix

Set `ANTHROPIC_AUTH_TOKEN` to a placeholder value (`x402-proxy-handles-auth`) since the proxy handles real authentication via x402/wallet signature:

```typescript
env: {
  ...cleanEnv,
  ANTHROPIC_BASE_URL: `http://localhost:${port}/api`,
  ANTHROPIC_AUTH_TOKEN: 'x402-proxy-handles-auth',
  ANTHROPIC_DEFAULT_SONNET_MODEL: sonnetModel,
  ...
}
```

## Test plan

- [ ] Run `brcc start --model nvidia/nemotron-ultra-253b`
- [ ] Confirm no login prompt appears and proxy routes correctly