### PR TITLE
fix: resolve Playwright accessibility type regression

### DIFF
--- a/src/social/browser.ts
+++ b/src/social/browser.ts
@@ -200,7 +200,9 @@ export class SocialBrowser {
   async snapshot(): Promise<string> {
     this.requirePage();
     // Playwright's accessibility snapshot returns a full AX tree
-    const axRoot = await this.page!.accessibility.snapshot({ interestingOnly: false });
+    // page.accessibility was removed from Playwright types in v1.46 but still works at runtime
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const axRoot = await (this.page! as any).accessibility.snapshot({ interestingOnly: false });
     if (!axRoot) return '';
     const { tree, refs } = serializeAxTree(axRoot as AxNode);
     this.lastRefs = refs;


### PR DESCRIPTION
## Problem
Build fails with TS2339 after upgrading to playwright-core ^1.49. Playwright removed `page.accessibility` from its TypeScript type definitions in v1.46, though the runtime API still works.

Error:
`src/social/browser.ts:203:37 - error TS2339: Property 'accessibility' does not exist on type 'Page'.`

## Fix
Cast `this.page!` to `any` to bypass the type error while preserving existing runtime behaviour.

## Testing
- `pnpm run build` completes successfully.