### PR TITLE
fix(stats): track ImageGen / VideoGen costs in usage insights

### DIFF
--- a/src/tools/imagegen.ts
+++ b/src/tools/imagegen.ts
@@ -21,6 +21,8 @@ import type { ContentLibrary } from '../content/library.js';
 import { checkImageBudget, recordImageAsset } from '../content/record-image.js';
 import { ModelClient } from '../agent/llm.js';
 import { analyzeMediaRequest, renderProposalForAskUser } from '../agent/media-router.js';
+import { recordUsage } from '../stats/tracker.js';
+import { findModel, estimateCostUsd } from '../gateway-models.js';
 
 interface ImageGenInput {
   prompt: string;
@@ -219,6 +221,20 @@ function buildExecute(deps: ImageGenDeps) {
     const fileSize = fs.statSync(outPath).size;
     const sizeKB = (fileSize / 1024).toFixed(1);
     const revisedPrompt = imageData.revised_prompt ? `\nRevised prompt: ${imageData.revised_prompt}` : '';
+
+    // Stats: record this generation so it shows up in `franklin insights`
+    // alongside chat spend. Before this, media generations bypassed
+    // recordUsage entirely (only LLM chat calls were tracked), so the
+    // insights panel under-reported total spend and never surfaced
+    // image-generation models in its "top models" list. Fire-and-forget —
+    // stats write must not fail a user-visible generation.
+    void (async () => {
+      try {
+        const m = await findModel(imageModel);
+        const estCost = m ? estimateCostUsd(m, { quantity: 1 }) : 0;
+        recordUsage(imageModel, 0, 0, estCost, 0);
+      } catch { /* ignore stats errors */ }
+    })();
 
     let contentSummary = '';
     if (contentId && deps.library) {

--- a/src/tools/videogen.ts
+++ b/src/tools/videogen.ts
@@ -36,6 +36,8 @@ import { loadChain, API_URLS, VERSION } from '../config.js';
 import type { ContentLibrary } from '../content/library.js';
 import { ModelClient } from '../agent/llm.js';
 import { analyzeMediaRequest, renderProposalForAskUser } from '../agent/media-router.js';
+import { recordUsage } from '../stats/tracker.js';
+import { findModel, estimateCostUsd } from '../gateway-models.js';
 
 interface VideoGenInput {
   prompt: string;
@@ -289,6 +291,21 @@ function buildExecute(deps: VideoGenDeps) {
       const fileSize = fs.statSync(outPath).size;
       const sizeMB = (fileSize / 1_048_576).toFixed(1);
       const dur = videoData.duration_seconds ?? duration;
+
+      // Stats: record this generation so it shows up in `franklin insights`
+      // alongside chat spend. Before this, media generations bypassed
+      // recordUsage entirely, so the insights panel under-reported total
+      // spend and never surfaced video models in its "top models" list.
+      // Prefer the live gateway price when the model is in the catalog;
+      // fall back to the legacy $0.05/s estimate otherwise. Fire-and-
+      // forget — stats write must not fail a user-visible generation.
+      void (async () => {
+        try {
+          const m = await findModel(videoModel);
+          const estCost = m ? estimateCostUsd(m, { duration_seconds: dur }) : estimateVideoCostUsd(dur);
+          recordUsage(videoModel, 0, 0, estCost, 0);
+        } catch { /* ignore stats errors */ }
+      })();
 
       let contentSummary = '';
       if (contentId && deps.library) {


### PR DESCRIPTION
## Summary

Before this, only chat LLM calls flowed through `recordUsage()`. The `ImageGen` and `VideoGen` tools wrote to the content library but never reported to the global stats file, so:

- `franklin insights` undercounted total 30-day spend by the exact amount spent on image + video generation.
- The "Top models" breakdown never surfaced `openai/gpt-image-1`, `bytedance/seedance-2.0`, `xai/grok-imagine-video`, etc. even when they were the dominant cost in a session.
- Monthly projections in insights were similarly low.

## Changes

On successful generation each tool now fires a fire-and-forget `recordUsage(model, 0, 0, costUsd, 0)`:

- Input/output tokens stay at 0 — image/video models don't bill by token.
- The cost is pulled from the live gateway catalog via `findModel` + `estimateCostUsd`, the same path the AskUser cost preview uses, so the recorded amount matches the amount the user was quoted.
- When the catalog lookup fails (offline / stale cache), the tools fall back to a hardcoded estimate (ImageGen: 0, VideoGen: the legacy `$0.05/s`) so stats still get an entry — under-approximate is better than missing.

## Design notes

- **Fire-and-forget, error-swallowing on purpose.** A `~/.blockrun/stats.json` write failure must not turn a paid generation into a user-visible error, and stats accuracy matters less than not losing the output.
- **No schema change.** The existing `recordUsage` signature handles `inputTokens=0` + `outputTokens=0` + explicit `costUsd` fine; nothing in the stats tracker or the insights engine needs to learn about media models specifically.
- **Scope deliberately small** — only the two tools, +33 lines across 2 files, zero net changes to any chat flow.

## Test plan

1. Run `franklin insights` → note baseline `Total Cost` and `Top Models` list.
2. Generate one image with a known-cost model, e.g.
   ```
   franklin --prompt "use zai/cogview-4 to generate a tiny red dot"
   ```
   (cogview-4 is catalog-priced at \$0.015/img.)
3. Run `franklin insights` again.
   - `Total Cost` should increase by ~\$0.0158 (0.015 + 5% gateway margin).
   - `Top Models` should contain a new row for `zai/cogview-4` with 1 request.
4. Repeat for VideoGen with any Seedance variant and confirm a per-second entry is written.

Verified locally on Base chain. The VS Code extension's Insights panel (which reads the same `stats.json`) also immediately reflected the new entries.

## Related

- The same `stats.json` is consumed by the VS Code extension's Insights panel (via `generateInsights`), so this fix lands media costs in both the CLI and the extension with a single change.