### PR TITLE
fix(imagegen): bump image-to-image timeout to 180s (was 60s shared with t2i)

### DIFF
--- a/src/tools/imagegen.ts
+++ b/src/tools/imagegen.ts
@@ -283,7 +283,14 @@ function buildExecute(deps: ImageGenDeps) {
   };
 
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 60_000); // 60s timeout
+  // Reference-image mode (gpt-image-2 edits) is meaningfully slower than
+  // pure text-to-image: the model is reasoning-driven and the request
+  // body carries a few MB of base64. The shared 60s budget has to cover
+  // both x402 retry attempts plus the actual generation, which made
+  // image-to-image effectively always time out. Image-to-image gets 3
+  // minutes; text-to-image keeps the original 60s.
+  const timeoutMs = referenceImage ? 180_000 : 60_000;
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
     // First request — will get 402
@@ -404,7 +411,12 @@ function buildExecute(deps: ImageGenDeps) {
   } catch (err) {
     const msg = (err as Error).message || '';
     if (msg.includes('abort')) {
-      return { output: 'Image generation timed out (60s limit). Try a simpler prompt.', isError: true };
+      return {
+        output: referenceImage
+          ? 'Image-to-image timed out (180s limit). The reference image may be too large or the model under load — try a smaller image or simpler prompt.'
+          : 'Image generation timed out (60s limit). Try a simpler prompt.',
+        isError: true,
+      };
     }
     return { output: `Error: ${msg}`, isError: true };
   } finally {


### PR DESCRIPTION
## Summary

The 60s `setTimeout` on the main `/v1/images/{generations,image2image}` fetch in `src/tools/imagegen.ts` covers both x402 retry attempts AND the actual generation. That budget is generous for text-to-image but consistently insufficient for image-to-image with gpt-image-2.

## Root cause

\`\`\`typescript
const controller = new AbortController();
const timeout = setTimeout(() => controller.abort(), 60_000); // 60s timeout
\`\`\`

For text-to-image (gpt-image-1, ~10–30s) — fine. For image-to-image (gpt-image-2):

- gpt-image-2 is reasoning-driven; an edit easily takes 60–150s on its own.
- The request body carries a few MB of base64 reference image, adding measurable upload time.
- The timeout shares its budget across the 402 round trip plus the paid retry.

End result: every gpt-image-2 image-to-image call hits \`AbortError\` before upstream returns, with a misleading error message (\"Image generation timed out (60s limit). Try a simpler prompt.\") that made it look like a server problem.

## Reproduction

\`\`\`bash
franklin
/model sonnet
> use openai/gpt-image-2 with reference image /any/normal/photo.png to generate <whatever>
\`\`\`

Hangs at AbortError every time on a 1–4MB reference image.

## Fix

Split the budget by mode:

- **image-to-image**: 180s (3 minutes — comfortably covers worst-case gpt-image-2 edits)
- **text-to-image**: 60s (unchanged)

Also updates the timeout error message so users know the longer limit applies and gives more relevant remediation hints (smaller image / simpler prompt) when the reference-image path was taken.

## Out of scope

- The existing 30s timeouts on \`resolveReferenceImage\` (URL fetch) and on the result download stay unchanged — those are network-bound and shouldn't routinely be slow.
- No change to text-to-image behavior, x402 flow, or the request schema.

## Test plan

1. Pick any 1–4MB PNG.
2. \`franklin\` → \`/model sonnet\`
3. \`use openai/gpt-image-2 with reference image /path/to/img.png to generate something\`
4. Before this patch: AbortError after ~60s every time.
5. After this patch: completes in 60–120s typically; only hits the new 180s ceiling under truly degraded conditions.

\`\`\`
src/tools/imagegen.ts | 16 ++++++++++++++--
1 file changed, 14 insertions(+), 2 deletions(-)
\`\`\`