### PR TITLE
feat(config): make per-turn spend limit user-configurable

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -549,13 +549,16 @@ export async function interactiveSession(
     let turnSpend = 0;                                   // Cost spent this user turn (USD)
     // Hard circuit breaker per user message — defends user wallets against
     // a runaway model+tool combo on a single prompt. User-overridable via
-    // `franklin config set max-turn-spend-usd <number>`. A value of "0"
-    // (or negative / non-numeric) disables the cap entirely.
+    // `franklin config set max-turn-spend-usd <number>`. Explicit "0" or a
+    // negative number disables the cap; a non-numeric / unparseable value
+    // is treated as a typo and falls back to the safe default rather than
+    // silently removing the wallet guard.
     const turnSpendCap = (() => {
       const raw = loadConfig()['max-turn-spend-usd'];
       if (raw == null) return 0.25;
       const parsed = Number(raw);
-      if (!Number.isFinite(parsed) || parsed <= 0) return Infinity;
+      if (!Number.isFinite(parsed)) return 0.25;   // typo → keep default
+      if (parsed <= 0) return Infinity;            // explicit opt-out
       return parsed;
     })();
     const MAX_TURN_SPEND_USD = turnSpendCap;

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -17,6 +17,7 @@ import { resetToolSessionState } from '../tools/index.js';
 import { CORE_TOOL_NAMES, dynamicToolsEnabled } from '../tools/tool-categories.js';
 import { createActivateToolCapability } from '../tools/activate.js';
 import { recordUsage } from '../stats/tracker.js';
+import { loadConfig } from '../commands/config.js';
 import { recordSessionUsage } from '../stats/session-tracker.js';
 import { appendAudit, extractLastUserPrompt } from '../stats/audit.js';
 import { estimateCost, OPUS_PRICING } from '../pricing.js';
@@ -546,7 +547,18 @@ export async function interactiveSession(
     let consecutiveTinyResponses = 0;                    // Count of consecutive calls with <10 output tokens
     const MAX_TINY_RESPONSES = 2;                        // Break after N tiny responses — if 2 calls return near-empty, something is wrong
     let turnSpend = 0;                                   // Cost spent this user turn (USD)
-    const MAX_TURN_SPEND_USD = 0.25;                    // Hard circuit breaker per user message (lowered — user wallets are real money)
+    // Hard circuit breaker per user message — defends user wallets against
+    // a runaway model+tool combo on a single prompt. User-overridable via
+    // `franklin config set max-turn-spend-usd <number>`. A value of "0"
+    // (or negative / non-numeric) disables the cap entirely.
+    const turnSpendCap = (() => {
+      const raw = loadConfig()['max-turn-spend-usd'];
+      if (raw == null) return 0.25;
+      const parsed = Number(raw);
+      if (!Number.isFinite(parsed) || parsed <= 0) return Infinity;
+      return parsed;
+    })();
+    const MAX_TURN_SPEND_USD = turnSpendCap;
 
     // ── Turn analysis (one classifier call, drives routing + prefetch) ──
     // Single LLM pass that answers every routing-adjacent question the

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -14,6 +14,7 @@ const VALID_KEYS = [
   'smart-routing',
   'permission-mode',
   'max-turns',
+  'max-turn-spend-usd',
   'auto-compact',
   'session-save',
   'debug',
@@ -29,6 +30,13 @@ export interface AppConfig {
   'smart-routing'?: string;
   'permission-mode'?: string;
   'max-turns'?: string;
+  /**
+   * Hard per-turn spend ceiling in USD (default $0.25). Numeric string,
+   * e.g. "0.5" or "2". Set to "0" to disable the cap. The agent loop
+   * stops a turn the moment cumulative cost crosses this threshold,
+   * preventing a runaway model + tool combo from draining the wallet.
+   */
+  'max-turn-spend-usd'?: string;
   'auto-compact'?: string;
   'session-save'?: string;
   'debug'?: string;


### PR DESCRIPTION
## Summary

The hard \$0.25 per-turn spend ceiling in \`src/agent/loop.ts\` has been hard-coded since it was added. It's a safe default for typical chat, but it routinely fires for legitimate workloads where a single user prompt triggers expensive paid tools (image-to-image with gpt-image-2, multi-step VideoGen, large WebFetch+research turns) — even though the user is fully aware they're spending more than \$0.25 on the request.

When the limit hits, the user sees:

> ⚠️ Turn spend limit reached (\$0.269 > \$0.25). Stopping to protect your wallet. Try again with a clearer prompt or a different model.

…and the only way out is editing the source.

## Changes

New config key **\`max-turn-spend-usd\`** read once per turn at the top of \`interactiveSession\`:

\`\`\`bash
franklin config set max-turn-spend-usd 1.0   # bump to \$1
franklin config set max-turn-spend-usd 0     # disable entirely
franklin config unset max-turn-spend-usd     # back to default \$0.25
\`\`\`

Resolution:

| value | behavior |
|---|---|
| unset / non-numeric | keep \$0.25 default (current behavior) |
| \`0\` or negative | cap removed (\`Infinity\`), warning never fires |
| positive number | that value as the ceiling |

The existing warning text already prints the active value, so users always see exactly what limit they hit.

## Files

- \`src/commands/config.ts\` — add \`max-turn-spend-usd\` to \`VALID_KEYS\` + \`AppConfig\` with a doc comment
- \`src/agent/loop.ts\` — replace the hard-coded \`const MAX_TURN_SPEND_USD = 0.25\` with a config read at turn start

\`\`\`
src/agent/loop.ts      | 14 +++++++++++++-
src/commands/config.ts |  8 ++++++++
2 files changed, 21 insertions(+), 1 deletion(-)
\`\`\`

## Out of scope

- No change to the breaker logic itself, warning text, or any other spend-tracking behavior.
- No new CLI subcommand — \`config set\` already covers this.
- No new env var — config file is the right place for per-user overrides.

## Test plan

\`\`\`bash
# Default — limit at \$0.25
franklin --prompt "<expensive multi-step task>"
# → ⚠️ Turn spend limit reached (\$0.32 > \$0.25). Stopping…

# Raise the cap
franklin config set max-turn-spend-usd 2.0
franklin --prompt "<same task>"
# → completes; runs to whatever budget

# Disable entirely
franklin config set max-turn-spend-usd 0
# → no warning, agent runs to natural completion

# Reset
franklin config unset max-turn-spend-usd
# → back to \$0.25 default
\`\`\`

## Related

Comes from a real-world hit on PR #19's image-to-image flow — a successful gpt-image-2 edit (\$0.06) + Sonnet planning + a couple of retries can land just over \$0.25 on a single prompt the user definitely intended to send. With #19 merged, image-to-image will succeed more often, and this PR makes sure success doesn't get cut off mid-stream by an over-conservative default.