### PR TITLE
fix(stats): savings calc no longer goes negative when user spends on media

### DIFF
--- a/src/panel/html.ts
+++ b/src/panel/html.ts
@@ -684,8 +684,15 @@ async function loadOverview() {
     document.getElementById('period-info').textContent = stats.period || '';
 
     if (stats.opusCost > 0) {
-      const saved = stats.saved || (stats.opusCost - stats.totalCostUsd);
-      const pct = stats.savedPct || ((1 - stats.totalCostUsd / stats.opusCost) * 100);
+      // tracker.ts now returns saved already clamped to >= 0 and opusCost
+      // already inclusive of media (so comparing to totalCostUsd is
+      // apples-to-apples). Older summaries — or the rare path where saved
+      // is undefined — get the same Math.max clamp here so the panel
+      // never shows a negative dollar amount.
+      const saved = Math.max(0, stats.saved != null ? stats.saved : (stats.opusCost - stats.totalCostUsd));
+      const pct = stats.savedPct != null
+        ? Math.max(0, stats.savedPct)
+        : (stats.opusCost > 0 ? Math.max(0, (saved / stats.opusCost) * 100) : 0);
       document.getElementById('savings-hero').style.display = 'flex';
       document.getElementById('savings-amount').textContent = usdBig(saved);
       document.getElementById('savings-pct').textContent = pct.toFixed(0) + '%';

--- a/src/stats/tracker.ts
+++ b/src/stats/tracker.ts
@@ -257,6 +257,10 @@ export function recordUsage(
 export function getStatsSummary(): {
   stats: Stats;
   opusCost: number;
+  /** All chat / token-billed model spend (excludes image / video / music). */
+  chatOnlyCost: number;
+  /** Per-image / per-second / per-track media generation spend. */
+  mediaCost: number;
   saved: number;
   savedPct: number;
   avgCostPerRequest: number;
@@ -264,12 +268,36 @@ export function getStatsSummary(): {
 } {
   const stats = loadStats();
 
-  // Calculate what it would cost with the Opus-tier baseline
-  const opusCost =
+  // Hypothetical "if you'd used Opus for everything" baseline. Opus is a
+  // chat model — it can't replace ImageGen / VideoGen / Music (per_image,
+  // per_second, per_track billing), so for those rows the Opus-equivalent
+  // cost IS just the actual cost (no alternative). For chat rows, the
+  // baseline is the same tokens repriced at Opus rates.
+  //
+  // Walk byModel: rows with zero tokens are media (recordUsage stores
+  // image/video calls with inputTokens=0 outputTokens=0). Those count
+  // towards both sides equally; chat rows count at actual price on the
+  // "actual" side and at Opus rates on the "baseline" side. Keeping them
+  // on both sides means the displayed totals match the user's real
+  // spend rather than an unfamiliar chat-only subset.
+  let chatOnlyCost = 0;
+  let mediaCost = 0;
+  for (const m of Object.values(stats.byModel)) {
+    if ((m.inputTokens + m.outputTokens) > 0) chatOnlyCost += m.costUsd;
+    else mediaCost += m.costUsd;
+  }
+  const opusChatCost =
     (stats.totalInputTokens / 1_000_000) * OPUS_PRICING.input +
     (stats.totalOutputTokens / 1_000_000) * OPUS_PRICING.output;
+  // Display-side baseline: include media on both sides so "you spent X
+  // instead of Y" shows real, comparable totals.
+  const opusCost = opusChatCost + mediaCost;
 
-  const saved = opusCost - stats.totalCostUsd;
+  // Saved is the chat-side delta only — media nets to zero. Clamp to 0
+  // so a session where the user paid more than Opus-equivalent for chat
+  // (e.g. Sonnet 4.6 with extended thinking enabled) doesn't show a
+  // negative "savings" number; we just say zero saved.
+  const saved = Math.max(0, opusChatCost - chatOnlyCost);
   const savedPct = opusCost > 0 ? (saved / opusCost) * 100 : 0;
   const avgCostPerRequest =
     stats.totalRequests > 0 ? stats.totalCostUsd / stats.totalRequests : 0;
@@ -285,5 +313,5 @@ export function getStatsSummary(): {
     else period = `${days} days`;
   }
 
-  return { stats, opusCost, saved, savedPct, avgCostPerRequest, period };
+  return { stats, opusCost, chatOnlyCost, mediaCost, saved, savedPct, avgCostPerRequest, period };
 }


### PR DESCRIPTION
## Summary

The \"Saved vs Opus\" hero on the panel can display a negative dollar amount as soon as a user spends meaningfully on \`ImageGen\` or \`VideoGen\`. Real example just hit:

> \$-8.79
> You spent \$20.4896 instead of \$11.70

This happens because the comparison in \`getStatsSummary()\` mixes two different accounting universes.

## Root cause

\`src/stats/tracker.ts:268-272\`:

\`\`\`typescript
const opusCost =
  (stats.totalInputTokens / 1_000_000) * OPUS_PRICING.input +
  (stats.totalOutputTokens / 1_000_000) * OPUS_PRICING.output;
const saved = opusCost - stats.totalCostUsd;
\`\`\`

- \`opusCost\` only counts chat tokens (priced at Opus rates).
- \`stats.totalCostUsd\` includes every recorded costUsd — chat **plus** image / video / music gen.
- \`recordUsage\` writes media calls with \`inputTokens=0, outputTokens=0\` because per_image / per_second / per_track billing has no token concept, so they don't enter \`opusCost\` but they do enter \`totalCostUsd\`.

\`saved\` therefore equals \`(chat-Opus-vs-chosen-delta) − media_cost\`. Once media spend exceeds the chat delta, \`saved\` flips negative even though every chat call was strictly cheaper than Opus would have been.

## Fix

Walk \`byModel\` once and split spend by whether the row accumulated tokens:

- **chatOnlyCost** — rows that did (chat models)
- **mediaCost** — rows that didn't (image / video / music)

Then construct the comparison so media appears on both sides of \"you spent X instead of Y\":

\`\`\`typescript
const opusChatCost = (totalIn / 1M) * OPUS_PRICING.input + (totalOut / 1M) * OPUS_PRICING.output;
const opusCost     = opusChatCost + mediaCost;          // display baseline
const totalCostUsd = chatOnlyCost + mediaCost;          // unchanged
const saved        = Math.max(0, opusChatCost - chatOnlyCost);
\`\`\`

Media nets to zero in the diff, so \`saved\` correctly reflects only the chat-side win — and the \`Math.max(0, ...)\` clamp handles the edge case where the user deliberately picks a more expensive chat model than Opus (e.g. Sonnet 4.6 with extended thinking).

\`getStatsSummary\` now also returns \`chatOnlyCost\` and \`mediaCost\` for any future panel feature that wants to show the breakdown.

## Worked example

| | Before | After |
|---|---|---|
| chat spend | \$2.00 | \$2.00 |
| image spend | \$11.30 | \$11.30 |
| Opus chat baseline | \$11.70 | \$11.70 |
| **Saved displayed** | **−\$1.60** ❌ | **\$9.70** ✅ |
| \"You spent\" | \$13.30 | \$13.30 |
| \"instead of\" | \$11.70 | \$23.00 (= \$11.70 + \$11.30) |

Both displayed totals now match the user's actual wallet activity, savings is the chat-side delta only, and the number is never negative.

## Files

- \`src/stats/tracker.ts\` — split chat/media in \`getStatsSummary()\`, expose both on the return type, clamp \`saved\` to >= 0
- \`src/panel/html.ts\` — defensive: clamp \`saved\` and \`pct\` to >= 0 even if a stale \`stats\` object lacks \`saved\` (older panel sessions could otherwise still hit the negative path)

\`\`\`
src/panel/html.ts    | 11 +++++++++--
src/stats/tracker.ts | 38 +++++++++++++++++++++++++++++++++-----
2 files changed, 42 insertions(+), 7 deletions(-)
\`\`\`

## Out of scope

- \`src/stats/insights.ts\` already has a \`Math.max(0, ...)\` clamp on its own savings calc, so it never displayed a negative number — but its math has the same chat/media conflation. Could be aligned in a follow-up.
- No change to \`recordUsage\`, the on-disk schema, or any chat-only flow.

## Test plan

\`\`\`bash
# Reproduce the negative case (before)
franklin --prompt 'use bytedance/seedance-2.0 to generate a 5-second clip of clouds'
# repeat until media spend > chat-vs-Opus delta
franklin panel    # open dashboard → savings hero → see negative dollar
\`\`\`

After: same flow shows \"You spent \$X instead of \$Y, saved \$Z\" where Z >= 0 and X / Y both include media.