### PR TITLE
fix(deps): sync package-lock.json with package.json (unblocks CI)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3370,6 +3370,21 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
     },
+    "node_modules/jayson/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/jayson/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@blockrun/franklin",
-  "version": "3.10.0",
+  "version": "3.15.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockrun/franklin",
-      "version": "3.10.0",
+      "version": "3.15.9",
       "license": "Apache-2.0",
       "dependencies": {
-        "@blockrun/llm": "^1.4.2",
+        "@blockrun/llm": "^1.13.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@solana/spl-token": "^0.4.14",
         "@solana/web3.js": "^1.98.4",
@@ -129,9 +129,9 @@
       }
     },
     "node_modules/@blockrun/llm": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@blockrun/llm/-/llm-1.6.2.tgz",
-      "integrity": "sha512-VzuPlNu0JhKUrjvgGIINu2pEiENeXkZZpwkx22NkAjv2iy1WQvmIJP/6ji26f+02gy8zSRulFH4wvSYNgSwNXw==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@blockrun/llm/-/llm-1.13.0.tgz",
+      "integrity": "sha512-Hd2C2r+0VJl0L4csE10bwFEOtVPz+bAEu5pngC62UPFUe30RzaXgq9MIsUp1ZEAioqP0zdTuEDSdT2PGhuIM0w==",
       "license": "MIT",
       "dependencies": {
         "@blockrun/clawrouter": "^0.12.71",
@@ -3369,21 +3369,6 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
-    },
-    "node_modules/jayson/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
     },
     "node_modules/jayson/node_modules/ws": {
       "version": "7.5.10",


### PR DESCRIPTION
## Summary

CI is currently failing on every PR against main with:

\`\`\`
npm error Invalid: lock file's @blockrun/llm@1.6.2 does not satisfy @blockrun/llm@1.13.0
\`\`\`

This blocks PR #39 (docs banner) and any other in-flight PR.

## Root cause

Commit \`208d05b\` (\"chore(deps): bump @blockrun/llm to ^1.13.0 for Solana ESM fix\") bumped \`package.json\` but didn't refresh the lockfile. The bump landed via direct push to main, so the PR-only \`npm ci\` check never had a chance to catch the drift. Subsequent release commits extended the gap — project version drifted to \`3.15.9\` in package.json while the lockfile still recorded \`3.10.0\`.

## The fix

Just \`npm install --package-lock-only\` + commit. No package.json or source changes.

\`\`\`
$ npm ci --dry-run
changed 1 package in 291ms        ← passes after this commit
\`\`\`

## Diff summary

\`package-lock.json\` only — 6 insertions, 21 deletions:
- \`@blockrun/llm\` \`1.6.2\` → \`1.13.0\` (catches up to package.json)
- Project version \`3.10.0\` → \`3.15.9\` (catches up to package.json)
- One duplicate transitive \`utf-8-validate\` entry de-duplicated by npm

## After merge

All in-flight PRs recover their CI without author action. PR #39 in particular needs no changes — its CI will pass on the next run.

## Test plan

- [x] \`npm ci --dry-run\` passes locally on this branch
- [ ] CI passes on this PR
- [ ] PR #39 (docs banner) re-runs green after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)