### PR TITLE
Keep session open on provider error text

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -1858,7 +1858,14 @@ export async function interactiveSession(
         logger.error(
           `[franklin] Gateway returned an error text in lieu of an answer (${resolvedModel}): ${gatewayErr.message}`
         );
-        throw new Error(gatewayErr.message);
+        lastSessionActivity = Date.now();
+        persistSessionMeta();
+        onEvent({
+          kind: 'turn_done',
+          reason: 'error',
+          error: gatewayErr.message,
+        });
+        break;
       }
 
       // Reset recovery counter on successful completion


### PR DESCRIPTION
## Summary
- Handle gateway/provider errors returned as text without throwing out of the agent loop.
- End only the current turn with an error so the interactive session stays open.
- Persist session metadata before returning control to the prompt.

## Testing
- npm run build