### PR TITLE
feat(ui): inline short pastes, only collapse when >= 5 lines

### DIFF
--- a/src/ui/app.tsx
+++ b/src/ui/app.tsx
@@ -30,6 +30,9 @@ const DISABLE_BRACKETED_PASTE = '\x1b[?2004l';
 const USER_PROMPT_COLOR = '#FFD700';
 const PASTE_BLOCK_START = '\uE000PASTE:';
 const PASTE_BLOCK_END = ':PASTE\uE001';
+// Mirror Hermes: only collapse pastes of >= this many lines into a [Pasted ~N lines] block.
+// Short pastes (one-liners, 2-4 line snippets) inline as plain text so the model sees them verbatim.
+const PASTE_COLLAPSE_LINE_THRESHOLD = 5;
 
 const DISABLE_AUTO_WRAP = '\x1b[?7l';
 const ENABLE_AUTO_WRAP = '\x1b[?7h';
@@ -242,7 +245,11 @@ function PromptTextInput({ value, onChange, onSubmit, placeholder = '', focus = 
 
       if (!hasPasteEnd) return;
 
-      text = encodePasteBlock(pasteBufferRef.current);
+      const buffered = pasteBufferRef.current;
+      const lineCount = buffered.length === 0 ? 0 : buffered.split('\n').length;
+      text = lineCount >= PASTE_COLLAPSE_LINE_THRESHOLD
+        ? encodePasteBlock(buffered)
+        : buffered;
       pasteBufferRef.current = '';
       pasteActiveRef.current = false;
     }


### PR DESCRIPTION
## Problem

Every bracketed-paste — even a one-line prompt — was being replaced in the input box with a `[Pasted ~1 line]` placeholder. Concretely, pasting:

> *\"Buy a US phone number, then call +1-555-0123 in English and ask whether they're free for a 30-minute product demo on Thursday. Use a warm female voice and don't talk for more than two minutes.\"*

(1 line, ~230 chars) collapses to `[Pasted ~1 line]`. The user can't see what they pasted, and the LLM only sees the decoded content at submit time — but the in-flight UX is broken for short snippets.

Root cause: `findPasteBlocks(...) > 0` triggered the collapse unconditionally — no threshold check at all.

## Fix

Mirror Hermes's behavior: only collapse pastes of **>= 5 lines** into a `[Pasted ~N lines]` block. Shorter pastes get inserted as plain text so they render verbatim and behave like normal typed input.

The threshold lives in a single named constant (`PASTE_COLLAPSE_LINE_THRESHOLD`) right next to the other paste markers, so it's easy to promote to a config field later if needed.

## Comparison with other agents

| Agent       | Threshold                         |
|-------------|-----------------------------------|
| Claude Code | >= 4 lines                        |
| opencode    | >= 3 lines OR > 150 chars *(community has been complaining this is too aggressive)* |
| **Hermes**  | **>= 5 lines** *(adopted here)*   |
| Cursor      | ~10 lines / ~1 KB                 |
| Aider       | never collapses                   |

## Behavior table

| Paste                                | Before                  | After                  |
|--------------------------------------|-------------------------|------------------------|
| 1-line, 230-char prompt              | `[Pasted ~1 line]` ❌   | inline ✅              |
| 2-line shell command                 | `[Pasted ~2 lines]`     | inline ✅              |
| 4-line stack trace                   | `[Pasted ~4 lines]`     | inline ✅              |
| 5-line code block                    | `[Pasted ~5 lines]`     | `[Pasted ~5 lines]` ✅ |
| 50-line log dump                     | `[Pasted ~50 lines]`    | `[Pasted ~50 lines]` ✅|

## Test plan

- [x] `npm run build` passes
- [x] Manual: paste the demo prompt above — renders inline, no `[Pasted]` placeholder
- [x] Manual: paste a 5+ line snippet — collapses to `[Pasted ~N lines]` as before
- [x] Manual: navigate with arrow keys / backspace through both short and collapsed pastes — no regressions
- [x] Submit decodes correctly in both branches (collapsed pastes still expand to original content at submit time)

## Scope

Single-file change to `src/ui/app.tsx`. No new dependencies. No behavior change for pastes that exceed the threshold.