### PR TITLE
feat(voice): expose voicemail controls on VoiceCall tool

### DIFF
--- a/src/tools/voice.ts
+++ b/src/tools/voice.ts
@@ -283,6 +283,20 @@ export const voiceCallCapability: CapabilityHandler = {
           type: 'boolean',
           description: 'If true, AI waits for the recipient to speak first before talking.',
         },
+        voicemail_action: {
+          type: 'string',
+          enum: ['hangup', 'leave_message', 'ignore'],
+          description:
+            'What to do if voicemail is detected. Default (omitted): hang up without a message. ' +
+            '"leave_message" speaks voicemail_message once then hangs up (voicemail_message required). ' +
+            '"ignore" skips detection and treats the call as live — only use when sure a human answers.',
+        },
+        voicemail_message: {
+          type: 'string',
+          description:
+            'The message to leave when voicemail_action is "leave_message" (≤1000 chars). ' +
+            'Voicemail is one-way — this is spoken once as a monologue, there is no back-and-forth.',
+        },
       },
       required: ['to', 'from', 'task'],
     },
@@ -306,6 +320,8 @@ export const voiceCallCapability: CapabilityHandler = {
     if (typeof input.language === 'string') body.language = input.language;
     if (typeof input.first_sentence === 'string') body.first_sentence = input.first_sentence;
     if (typeof input.wait_for_greeting === 'boolean') body.wait_for_greeting = input.wait_for_greeting;
+    if (typeof input.voicemail_action === 'string') body.voicemail_action = input.voicemail_action;
+    if (typeof input.voicemail_message === 'string') body.voicemail_message = input.voicemail_message;
 
     try {
       const res = await postWithPayment<Record<string, unknown>>(


### PR DESCRIPTION
## What

Adds two optional params to the `VoiceCall` tool so the agent can control voicemail behavior from natural language:

- `voicemail_action`: `hangup` | `leave_message` | `ignore`
- `voicemail_message`: the message to speak when `leave_message` is set

Before this, a request like *"call my client, and if it goes to voicemail leave this message..."* had nowhere structured to go — it could only be stuffed into the free-text `task` prompt as fragile if-then logic. Now the agent parses intent into real params.

The schema description spells out that voicemail is a one-way monologue (spoken once, no back-and-forth) so the model doesn't try to script a conversation with a recording.

## Behavior

Both fields are optional and only forwarded when present, so ordinary calls are completely unchanged — voicemail still hangs up by default unless the user explicitly asks to leave a message.

## ⚠️ Merge order

**Depends on the gateway accepting these fields** — blockrun PR [#26](https://github.com/BlockRunAI/blockrun/pull/26). The gateway validates the call body with `.strict()`, so it will reject `voicemail_*` until that PR is merged and deployed. Merge + deploy blockrun #26 first, then this.

(Safety cushion: the params are only sent when the user asks about voicemail, so even out of order, plain calls keep working — only the voicemail path would fail.)

## Test plan

- [x] `npm run build` passes (tsc clean)
- [ ] After blockrun #26 deploys: end-to-end call with `voicemail_action: leave_message` → verify message is left
- [ ] Plain call (no voicemail params) → verify unchanged hang-up-on-voicemail behavior