### PR TITLE
Expose VoiceCall timing and model controls

### DIFF
--- a/src/tools/voice.ts
+++ b/src/tools/voice.ts
@@ -222,6 +222,26 @@ async function extractPaymentReq(response: Response): Promise<string | null> {
 
 // ─── Tools ─────────────────────────────────────────────────────────────────
 
+export function buildVoiceCallBody(input: Record<string, unknown>): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    to: input.to,
+    from: input.from,
+    task: input.task,
+  };
+  // The gateway validates additionalProperties: false - only forward known
+  // optional fields, don't echo back whatever the caller passed.
+  if (typeof input.voice === 'string') body.voice = input.voice;
+  if (typeof input.max_duration === 'number') body.max_duration = input.max_duration;
+  if (typeof input.language === 'string') body.language = input.language;
+  if (typeof input.first_sentence === 'string') body.first_sentence = input.first_sentence;
+  if (typeof input.wait_for_greeting === 'boolean') body.wait_for_greeting = input.wait_for_greeting;
+  if (typeof input.voicemail_action === 'string') body.voicemail_action = input.voicemail_action;
+  if (typeof input.voicemail_message === 'string') body.voicemail_message = input.voicemail_message;
+  if (typeof input.interruption_threshold === 'number') body.interruption_threshold = input.interruption_threshold;
+  if (typeof input.model === 'string') body.model = input.model;
+  return body;
+}
+
 export const voiceCallCapability: CapabilityHandler = {
   spec: {
     name: 'VoiceCall',
@@ -297,6 +317,18 @@ export const voiceCallCapability: CapabilityHandler = {
             'The message to leave when voicemail_action is "leave_message" (≤1000 chars). ' +
             'Voicemail is one-way — this is spoken once as a monologue, there is no back-and-forth.',
         },
+        interruption_threshold: {
+          type: 'integer',
+          minimum: 50,
+          maximum: 500,
+          description:
+            'Milliseconds of recipient speech before the agent pauses to listen (50-500).',
+        },
+        model: {
+          type: 'string',
+          enum: ['base', 'enhanced', 'turbo'],
+          description: 'Call model tier to use for the conversation.',
+        },
       },
       required: ['to', 'from', 'task'],
     },
@@ -308,20 +340,7 @@ export const voiceCallCapability: CapabilityHandler = {
       return { output: 'task required (10–4000 chars natural-language description)', isError: true };
     }
 
-    const body: Record<string, unknown> = {
-      to: input.to,
-      from: input.from,
-      task: input.task,
-    };
-    // The gateway validates additionalProperties: false — only forward known
-    // optional fields, don't echo back whatever the caller passed.
-    if (typeof input.voice === 'string') body.voice = input.voice;
-    if (typeof input.max_duration === 'number') body.max_duration = input.max_duration;
-    if (typeof input.language === 'string') body.language = input.language;
-    if (typeof input.first_sentence === 'string') body.first_sentence = input.first_sentence;
-    if (typeof input.wait_for_greeting === 'boolean') body.wait_for_greeting = input.wait_for_greeting;
-    if (typeof input.voicemail_action === 'string') body.voicemail_action = input.voicemail_action;
-    if (typeof input.voicemail_message === 'string') body.voicemail_message = input.voicemail_message;
+    const body = buildVoiceCallBody(input);
 
     try {
       const res = await postWithPayment<Record<string, unknown>>(

--- a/test/local.mjs
+++ b/test/local.mjs
@@ -9540,6 +9540,35 @@ test('journal-display: renderDisciplineFooter flags components below 3.0', async
 // Append-only with multiple rows per call_id so concurrent status polls don't
 // race. summary() picks the latest row per call_id.
 
+test('VoiceCall: exposes and forwards interruption/model controls', async () => {
+  const { buildVoiceCallBody, voiceCallCapability } = await import('../dist/tools/voice.js');
+  const props = voiceCallCapability.spec.input_schema.properties;
+
+  assert.equal(props.interruption_threshold.type, 'integer');
+  assert.equal(props.interruption_threshold.minimum, 50);
+  assert.equal(props.interruption_threshold.maximum, 500);
+  assert.deepEqual(props.model.enum, ['base', 'enhanced', 'turbo']);
+
+  const body = buildVoiceCallBody({
+    to: '+14155552671',
+    from: '+15705550123',
+    task: 'Confirm the appointment time and end the call politely.',
+    voice: 'maya',
+    interruption_threshold: 120,
+    model: 'turbo',
+    unexpected: 'ignored',
+  });
+
+  assert.deepEqual(body, {
+    to: '+14155552671',
+    from: '+15705550123',
+    task: 'Confirm the appointment time and end the call politely.',
+    voice: 'maya',
+    interruption_threshold: 120,
+    model: 'turbo',
+  });
+});
+
 test('CallLog: append + read round-trip preserves all fields', async () => {
   const { CallLog } = await import('../dist/phone/call-log.js');
   const tmpFile = join(mkdtempSync(join(tmpdir(), 'franklin-calls-')), 'calls.jsonl');


### PR DESCRIPTION
Closes #65.

Adds optional VoiceCall schema fields for `interruption_threshold` and `model`, and forwards both to `/v1/voice/call` only when provided. Existing calls are unchanged.

Tests:
- `npm run build`
- `node --test --test-reporter=spec --test-name-pattern "VoiceCall" test/local.mjs`

Note: I also attempted `npm test`; in this Windows checkout it fails in unrelated HOME/BLOCKRUN/session/logger fixture tests, while the new VoiceCall regression passes.

Happy to address any review feedback.