### PR TITLE
fix(ui): always probe clipboard for image, regardless of paste buffer content

### DIFF
--- a/src/ui/app.tsx
+++ b/src/ui/app.tsx
@@ -460,9 +460,10 @@ function PromptTextInput({ value, onChange, onSubmit, placeholder = '', focus = 
       // assumption holds for macOS Terminal/iTerm2 but NOT for several Linux
       // terminals — some send a filename, a `file://` URI, or a short binary
       // header alongside the image, which made the gate skip the probe and
-      // the image silently dropped (user-reported on Kali: clipboard had the
-      // image, opencode could paste it, Franklin couldn't). Verified in a
-      // Lima Ubuntu VM with xclip — non-empty buffer triggered the skip.
+      // the image silently dropped (user-reported on Kali: the clipboard
+      // image was readable by other tools but Franklin couldn't paste it).
+      // Verified in a Lima Ubuntu VM with xclip — non-empty buffer triggered
+      // the skip.
       //
       // Fix: ALWAYS probe the clipboard on a paste-end. If an image is there,
       // it wins; the bracketed-paste buffer text is treated as terminal noise

--- a/src/ui/app.tsx
+++ b/src/ui/app.tsx
@@ -454,35 +454,52 @@ function PromptTextInput({ value, onChange, onSubmit, placeholder = '', focus = 
       pasteBufferRef.current = '';
       pasteActiveRef.current = false;
 
-      // Image-paste detection: terminals deliver Cmd+V as a bracketed paste,
-      // but image bytes don't ride that stream — Terminal/iTerm2 just fire an
-      // empty (or whitespace-only) bracketed paste, while the actual image
-      // sits in the system clipboard. So when the buffered text is empty we
-      // probe the clipboard before falling through to plain text handling.
-      // (No race vs. real paste content: pasted text always populates the
-      // buffer before END arrives, so non-empty buffer = certainly text.)
-      if (buffered.trim().length === 0) {
-        // Clipboard probe + optional resize are async; the input handler
-        // returns now and updateValue happens once the Promise resolves.
-        // Capture the cursor offset so the block goes where the user pasted,
-        // even if they moved the cursor in the meantime.
-        const insertAt = currentCursorOffset;
-        tryReadClipboardImage().then((img) => {
-          let injected: string;
-          if (img && 'path' in img) injected = encodeImageBlock(img.path);
-          else if (img && 'error' in img) injected = `[Image rejected: ${img.error}] `;
-          else return; // no image on clipboard — nothing to do
+      // Image-paste detection. Original heuristic (3.25.0) only probed the
+      // clipboard when the bracketed-paste buffer was empty, assuming Cmd+V
+      // on an image-only clipboard always arrived as an empty paste. That
+      // assumption holds for macOS Terminal/iTerm2 but NOT for several Linux
+      // terminals — some send a filename, a `file://` URI, or a short binary
+      // header alongside the image, which made the gate skip the probe and
+      // the image silently dropped (user-reported on Kali: clipboard had the
+      // image, opencode could paste it, Franklin couldn't). Verified in a
+      // Lima Ubuntu VM with xclip — non-empty buffer triggered the skip.
+      //
+      // Fix: ALWAYS probe the clipboard on a paste-end. If an image is there,
+      // it wins; the bracketed-paste buffer text is treated as terminal noise
+      // and dropped. If no image, fall through to the normal text-paste path
+      // (collapse-to-block or inline) so text pastes are unaffected. The
+      // probe is async (osascript / xclip / wl-paste shell-out, 30-100 ms),
+      // so the handler returns immediately and updateValue happens when the
+      // Promise resolves.
+      const insertAt = currentCursorOffset;
+      tryReadClipboardImage().then((img) => {
+        if (img && 'path' in img) {
+          // Image wins — drop the bracketed-paste buffer (likely a stub the
+          // terminal sent for the image).
+          const injected = encodeImageBlock(img.path);
           const cur = valueRef.current;
           const at = Math.min(insertAt, cur.length);
           updateValue(cur.slice(0, at) + injected + cur.slice(at), at + injected.length);
-        }).catch(() => { /* best-effort, errors already mapped to inline text above */ });
-        return;
-      }
-
-      const lineCount = buffered.split('\n').length;
-      text = lineCount >= PASTE_COLLAPSE_LINE_THRESHOLD
-        ? encodePasteBlock(buffered)
-        : buffered;
+          return;
+        }
+        if (img && 'error' in img) {
+          const injected = `[Image rejected: ${img.error}] `;
+          const cur = valueRef.current;
+          const at = Math.min(insertAt, cur.length);
+          updateValue(cur.slice(0, at) + injected + cur.slice(at), at + injected.length);
+          return;
+        }
+        // No image on the clipboard — treat as a normal text paste.
+        if (buffered.length === 0) return;
+        const lineCount = buffered.split('\n').length;
+        const textToInsert = lineCount >= PASTE_COLLAPSE_LINE_THRESHOLD
+          ? encodePasteBlock(buffered)
+          : buffered;
+        const cur = valueRef.current;
+        const at = Math.min(insertAt, cur.length);
+        updateValue(cur.slice(0, at) + textToInsert + cur.slice(at), at + textToInsert.length);
+      }).catch(() => { /* best-effort */ });
+      return;
     }
 
     if (!text) {


### PR DESCRIPTION
## Why

3.25.0 (the PR #76 / Cmd+V image paste shipping version) only probed the system clipboard for an image when the bracketed paste buffer arrived **empty**. That holds for macOS Terminal/iTerm2, but **breaks on several Linux terminals**: a user on Kali confirmed Franklin 3.25.0 silently dropped his image paste while opencode read the same clipboard fine.

## Root cause

Reproduced in a Lima Ubuntu 24.04 VM with `xclip` putting a real PNG on the X11 clipboard:

| Buffered bytes (what the terminal sends with the bracketed paste) | Old gate | Old result | New "always probe" |
|---|---|---|---|
| `""` (empty)                       | trim == 0 → probe   | ✅ image attached    | ✅ image attached |
| `"image.png"` (file name)          | non-empty → **skip**| ❌ text inserted     | ✅ image attached |
| `"file:///tmp/x.png"` (file URI)   | non-empty → **skip**| ❌ text inserted     | ✅ image attached |
| `"\x89PNG\r\n\x1a\n"` (raw header) | non-empty → **skip**| ❌ garbage inserted  | ✅ image attached |

The Kali user's terminal evidently sends one of B/C/D; the gate skipped the probe and the image silently dropped. Same clipboard worked in opencode because opencode does not have this gate.

## Fix

Drop the gate. Always probe the clipboard on `paste-end`:
- Image found → image wins; the bracketed-paste buffer (likely a terminal-emitted stub) is dropped.
- No image → fall through to the existing text-paste flow (collapse-to-block or inline).

Net behaviour for text pastes is unchanged. Net cost: one extra async probe (~30-100 ms via `osascript` / `xclip` / `wl-paste`) per paste. The handler returns synchronously, so users see no perceptible latency.

## Verified

- `npm run build` clean.
- Lima Ubuntu VM regression: with a real PNG on the X11 clipboard, scenarios A/B/C/D all attach the image (vs. the old gate where only A worked).
- Text-paste path untouched — `tryReadClipboardImage` returns null on a text-only clipboard, code falls through to `encodePasteBlock` / inline as before.

## Scope

One file: `src/ui/app.tsx` (+24, -14). No new dependencies. Same Linux/macOS coverage as 3.25.0 — Windows still not wired.

## Follow-up

User-facing: ship as **3.25.1**. The reporter (on Kali Linux) can pick it up with `npm i -g @blockrun/franklin@3.25.1` once published. Confirmed his clipboard is good (opencode reads it) and his Franklin version is 3.25.0 — this PR closes the gap.