### PR TITLE
fix(ui): improve image paste fallback and display

### DIFF
--- a/src/ui/app.tsx
+++ b/src/ui/app.tsx
@@ -149,6 +149,18 @@ function decodePromptValue(value: string): string {
   return decoded + value.slice(cursor);
 }
 
+function promptValueForDisplay(value: string): string {
+  let rendered = '';
+  let cursor = 0;
+
+  for (const block of findPasteBlocks(value)) {
+    rendered += value.slice(cursor, block.start) + pasteSummary(block);
+    cursor = block.end;
+  }
+
+  return rendered + value.slice(cursor);
+}
+
 /**
  * Read the system clipboard, and if it currently holds an image, save it to
  * a temp file and return the absolute path. Otherwise return null.
@@ -370,6 +382,18 @@ function PromptTextInput({ value, onChange, onSubmit, placeholder = '', focus = 
     setCursorOffset(cursorOffsetRef.current);
   }, [onChange]);
 
+  const insertClipboardImageAt = useCallback((insertAt: number) => {
+    tryReadClipboardImage().then((img) => {
+      let injected: string;
+      if (img && 'path' in img) injected = encodeImageBlock(img.path);
+      else if (img && 'error' in img) injected = `[Image rejected: ${img.error}] `;
+      else return; // no image on clipboard — nothing to do
+      const cur = valueRef.current;
+      const at = Math.min(insertAt, cur.length);
+      updateValue(cur.slice(0, at) + injected + cur.slice(at), at + injected.length);
+    }).catch(() => { /* best-effort, errors already mapped to inline text above */ });
+  }, [updateValue]);
+
   useInput((input, key) => {
     if (!focus) return;
 
@@ -388,7 +412,7 @@ function PromptTextInput({ value, onChange, onSubmit, placeholder = '', focus = 
     }
 
     if (key.return && !isPasting) {
-      onSubmit(decodePromptValue(currentValue));
+      onSubmit(currentValue);
       return;
     }
 
@@ -440,6 +464,14 @@ function PromptTextInput({ value, onChange, onSubmit, placeholder = '', focus = 
       return;
     }
 
+    // Some Linux terminals do not emit a bracketed-paste event for image-only
+    // clipboard contents. Ctrl+V gives users a raw-key fallback that probes the
+    // same clipboard image path without relying on terminal paste behavior.
+    if (key.ctrl && input === 'v') {
+      insertClipboardImageAt(currentCursorOffset);
+      return;
+    }
+
     if (key.upArrow || key.downArrow || key.tab || key.ctrl || key.meta) return;
 
     let text = normalizeInputNewlines(stripPasteMarkers(input));
@@ -462,20 +494,7 @@ function PromptTextInput({ value, onChange, onSubmit, placeholder = '', focus = 
       // (No race vs. real paste content: pasted text always populates the
       // buffer before END arrives, so non-empty buffer = certainly text.)
       if (buffered.trim().length === 0) {
-        // Clipboard probe + optional resize are async; the input handler
-        // returns now and updateValue happens once the Promise resolves.
-        // Capture the cursor offset so the block goes where the user pasted,
-        // even if they moved the cursor in the meantime.
-        const insertAt = currentCursorOffset;
-        tryReadClipboardImage().then((img) => {
-          let injected: string;
-          if (img && 'path' in img) injected = encodeImageBlock(img.path);
-          else if (img && 'error' in img) injected = `[Image rejected: ${img.error}] `;
-          else return; // no image on clipboard — nothing to do
-          const cur = valueRef.current;
-          const at = Math.min(insertAt, cur.length);
-          updateValue(cur.slice(0, at) + injected + cur.slice(at), at + injected.length);
-        }).catch(() => { /* best-effort, errors already mapped to inline text above */ });
+        insertClipboardImageAt(currentCursorOffset);
         return;
       }
 
@@ -506,7 +525,7 @@ function PromptTextInput({ value, onChange, onSubmit, placeholder = '', focus = 
 }
 
 function formatUserPromptForDisplay(value: string): string {
-  return `❯ ${decodePromptValue(value)}`;
+  return `❯ ${promptValueForDisplay(value)}`;
 }
 
 function disableTerminalAutoWrap(): (() => void) | undefined {
@@ -1185,7 +1204,7 @@ function RunCodeApp({
           turnTierRef.current = undefined;
           turnSavingsRef.current = undefined;
           turnCtxPctRef.current = undefined;
-          onSubmit(lastPrompt);
+          onSubmit(decodePromptValue(lastPrompt).trim());
           return;
 
         default:
@@ -1235,7 +1254,7 @@ function RunCodeApp({
     turnTierRef.current = undefined;
     turnSavingsRef.current = undefined;
     turnCtxPctRef.current = undefined;
-    onSubmit(trimmed);
+    onSubmit(decodePromptValue(trimmed).trim());
   }, [ready, currentModel, totalCost, onSubmit, onModelChange, requestExit, lastPrompt, inputHistory, showStatus]);
 
   // Mouse support — OFF by default because Node stdin is shared: mouse escape


### PR DESCRIPTION
## Summary
- add a Ctrl+V fallback that explicitly probes the clipboard image for Linux terminals that do not emit an image-only bracketed paste event
- keep image placeholders visible in submitted prompt history instead of showing temp file paths
- decode image placeholders only when sending the prompt to the agent

## Testing
- npm run build
- manually verified Ctrl+V inserts an image placeholder locally