### PR TITLE
fix(agent): restore GPT-5 / Grok families and surface real errors

### DIFF
--- a/src/agent/llm.ts
+++ b/src/agent/llm.ts
@@ -192,6 +192,62 @@ function createModelTimeoutError(stage: 'request' | 'stream', model: string, tim
   return new Error(`Model ${stage} timed out after ${timeoutMs}ms on ${model}`);
 }
 
+/**
+ * Walk a tool-schema object and drop any `enum` whose entries are strings
+ * containing "/". Grok's request validator rejects such enums outright (see
+ * the call site for the verbatim upstream error). The model still sees the
+ * intended values via the tool's description text, so dropping the schema-
+ * level constraint is purely a compatibility shim — no behavioral loss.
+ */
+function stripSlashEnumsForGrok(node: unknown): unknown {
+  if (Array.isArray(node)) return node.map(stripSlashEnumsForGrok);
+  if (!node || typeof node !== 'object') return node;
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(node as Record<string, unknown>)) {
+    if (
+      k === 'enum' &&
+      Array.isArray(v) &&
+      v.some((x) => typeof x === 'string' && x.includes('/'))
+    ) {
+      continue; // drop the constraint entirely
+    }
+    out[k] = stripSlashEnumsForGrok(v);
+  }
+  return out;
+}
+
+/**
+ * Wrap `fetch()` so that undici's opaque `TypeError: fetch failed` is
+ * replaced with the underlying network reason (ECONNRESET, UND_ERR_*,
+ * certificate, DNS, etc.). Without this, every transient connection blip
+ * surfaces to the user as "Network: fetch failed" with no way to tell
+ * whether it's their network, the gateway, or the upstream provider.
+ *
+ * Verified 2026-06-03: stress-testing claude-sonnet-4.6 reproduces
+ * intermittent "fetch failed" (cheetah's report on 3.25.0). With this
+ * helper the message becomes e.g. "fetch failed (UND_ERR_SOCKET: other
+ * side closed)" which is actionable.
+ */
+async function fetchWithUnwrappedCause(
+  url: string,
+  init: RequestInit,
+): Promise<Response> {
+  try {
+    return await fetch(url, init);
+  } catch (err) {
+    if (err instanceof Error && err.message === 'fetch failed' && err.cause) {
+      const cause = err.cause as { code?: string; message?: string; errno?: string };
+      const detail = cause.code || cause.errno || cause.message;
+      if (detail) {
+        const enriched = new Error(`fetch failed (${detail})`);
+        (enriched as Error & { cause?: unknown }).cause = err.cause;
+        throw enriched;
+      }
+    }
+    throw err;
+  }
+}
+
 async function withAbortableTimeout<T>(
   work: () => Promise<T>,
   controller: AbortController,
@@ -543,6 +599,21 @@ export class ModelClient {
       delete requestPayload['tool_choice'];
     }
 
+    // ── Grok: strip enum constraints containing "/" from tool schemas ────────
+    // Verified 2026-06-03 via Franklin repro: xAI's request validator hard-
+    // rejects any tool-schema enum string containing "/", e.g.
+    //   "[engine_imposed] /properties/endpoint/enum/0: '/' in 'enum' string
+    //    value is currently not supported"
+    // The Surf tools (and a few others) use endpoint paths like
+    // "market/ranking" as enum values to constrain the model's choice. The
+    // path list is also enumerated in each tool's description text, so the
+    // model still sees the legal values — only the schema-level constraint
+    // gets dropped. Other providers keep the enum unchanged.
+    if (request.model.startsWith('xai/') && Array.isArray(requestPayload['tools'])) {
+      const tools = requestPayload['tools'] as Record<string, unknown>[];
+      requestPayload['tools'] = tools.map((tool) => stripSlashEnumsForGrok(tool));
+    }
+
     // ── GLM-specific optimizations ───────────────────────────────────────────
     // GLM models work best with temperature=0.8 per official zai spec.
     // Enable thinking mode only for explicit reasoning variants (-thinking-).
@@ -611,20 +682,20 @@ export class ModelClient {
       requestPayload = applyAnthropicPromptCaching(requestPayload, request);
     }
 
-    // ── GPT-5 / Codex: use "developer" role for system prompt ──────────────
-    // OpenAI GPT models give stronger instruction-following weight to the
-    // "developer" role. Move the top-level system prompt into messages[0]
-    // with role "developer" instead of the default "system".
-    const isGPT5OrCodex = request.model.includes('gpt-5') || request.model.includes('codex');
-    if (isGPT5OrCodex && typeof request.system === 'string' && request.system.length > 0) {
-      const systemRole = 'developer';
-      const existingMessages = (requestPayload['messages'] as unknown[]) || [];
-      requestPayload['messages'] = [
-        { role: systemRole, content: request.system },
-        ...existingMessages,
-      ];
-      delete requestPayload['system'];
-    }
+    // ── No client-side system → developer role rewrite for GPT-5/Codex ─────
+    // We used to move the top-level `system` field into `messages[0]` with
+    // role "developer" for GPT-5/Codex (OpenAI docs say that role gets
+    // stronger instruction-following weight). But the BlockRun gateway
+    // speaks Anthropic Messages, which only accepts user|assistant in
+    // messages[] — the developer-role payload returns HTTP 400 from the
+    // gateway's protocol validator BEFORE it ever reaches OpenAI:
+    //   {"error":{"message":"messages.0.role: Invalid option: expected
+    //    one of \"user\"|\"assistant\""}}
+    // Verified 2026-06-03 via direct curl + Franklin repro: all GPT-5
+    // family models (mini/nano/5.4/5.5) were silently failing under
+    // headless -p mode. Keep `system` as a top-level field and let the
+    // gateway translate to whatever the upstream needs (it already knows
+    // gpt-5 expects developer role internally).
 
     const body = JSON.stringify(requestPayload);
 
@@ -652,7 +723,7 @@ export class ModelClient {
 
     try {
       let response = await withAbortableTimeout(
-        () => fetch(endpoint, {
+        () => fetchWithUnwrappedCause(endpoint, {
           method: 'POST',
           headers,
           body,
@@ -673,7 +744,7 @@ export class ModelClient {
         }
 
         response = await withAbortableTimeout(
-          () => fetch(endpoint, {
+          () => fetchWithUnwrappedCause(endpoint, {
             method: 'POST',
             headers: { ...headers, ...paymentHeader },
             body,
@@ -733,7 +804,7 @@ export class ModelClient {
             console.error(`[franklin] tool_choice rejected by upstream; retrying without it (model=${request.model})`);
           }
           response = await withAbortableTimeout(
-            () => fetch(endpoint, {
+            () => fetchWithUnwrappedCause(endpoint, {
               method: 'POST',
               headers,
               body: retryBody,
@@ -750,7 +821,7 @@ export class ModelClient {
               return;
             }
             response = await withAbortableTimeout(
-              () => fetch(endpoint, {
+              () => fetchWithUnwrappedCause(endpoint, {
                 method: 'POST',
                 headers: { ...headers, ...paymentHeader },
                 body: retryBody,

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -456,6 +456,12 @@ async function runOneShot(agentConfig: AgentConfig, prompt: string): Promise<num
       process.stdout.write(event.text);
     } else if (event.kind === 'turn_done') {
       exitCode = oneShotExitCodeForTurnReason(event.reason);
+      // Without this, headless callers see exit 1 + zero stderr — impossible
+      // to triage. Verified 2026-06-03: GPT-5 family failing with HTTP 400
+      // from the gateway looked identical to a network timeout in `-p` mode.
+      if (event.reason !== 'completed' && event.error) {
+        process.stderr.write(`\n${event.error}\n`);
+      }
       process.stdout.write('\n');
     }
   });


### PR DESCRIPTION
## Summary

Two recent regressions silently broke whole model families on the headless `-p` path. Both were 400s from the gateway, but our headless one-shot mode never printed errors to stderr, so they looked like network failures. This PR fixes both regressions and makes future failures actually debuggable.

| Model | Before | After |
|---|---|---|
| `openai/gpt-5-mini` | exit 1, silent | ✅ |
| `openai/gpt-5-nano` | exit 1, silent | ✅ |
| `openai/gpt-5.4` | exit 1, silent | ✅ |
| `openai/gpt-5.5` | exit 1, silent | ✅ |
| `xai/grok-3` | exit 1, silent | ✅ |
| `xai/grok-4-0709` | exit 1, silent | ✅ |
| `xai/grok-4-1-fast-reasoning` | exit 1, silent | ✅ |

## Changes

### 1. Drop the GPT-5/Codex `developer`-role rewrite (`src/agent/llm.ts`)

We were rewriting any GPT-5/Codex request's `system` field into `messages[0]` with `role: \"developer\"`. The OpenAI Responses API does want that role internally, but **we don't call OpenAI directly — we call our gateway, which speaks the Anthropic Messages protocol and only accepts `user`/`assistant` in `messages[]`**. Verified live:

\`\`\`
$ curl -X POST https://blockrun.ai/api/v1/messages \
    -d '{\"model\":\"openai/gpt-5-mini\",\"messages\":[{\"role\":\"developer\",...}]}'
HTTP 400: messages.0.role: Invalid option: expected one of \"user\"|\"assistant\"
\`\`\`

Keeping `system` as the top-level field lets the gateway do the right translation downstream (it already knows GPT-5 expects `developer`). Regression introduced in 40ba6cf (Apr 13).

### 2. Strip slash-bearing tool-schema enums for xAI (`src/agent/llm.ts`)

xAI's validator hard-rejects any `enum` string containing `/`:

\`\`\`
[engine_imposed] /properties/endpoint/enum/0: '/' in 'enum' string value is currently not supported
\`\`\`

The Surf tools (#68) added `enum: [\"market/ranking\", \"market/futures\", ...]` — 26 entries, all with `/`. Result: every Grok call with Surf tools loaded got 400'd. Surf landed May 23; that's when Grok started failing.

Fix: walk tool schemas before dispatch; drop slash-bearing enums for `xai/*` only. The path list still appears in each tool's description, so the model sees the legal values — only the schema-level constraint is dropped. All other providers keep the enum unchanged.

### 3. Unwrap undici's `fetch failed` (`src/agent/llm.ts`)

`TypeError: fetch failed` is undici's outer wrapper; the real reason (`ECONNRESET`, `UND_ERR_SOCKET`, certificate, DNS, etc.) is on `error.cause.code`. Without unwrapping it, every transient gateway blip surfaced as `Network: fetch failed` with no way to triage whether it's the user's network, Cloudflare, or upstream. Now the message becomes e.g. `fetch failed (UND_ERR_SOCKET)`.

This doesn't fix the intermittent claude-sonnet-4.6 / glm-5.1 failures users have reported — those are gateway-side (long first-token latency on reasoning models + Cloud Run/Cloudflare idle-out). But the next time it fires, the message will say which one.

### 4. Forward turn-done errors to stderr in `-p` mode (`src/commands/start.ts`)

The headless one-shot runner only wrote `text_delta` events to stdout — it ignored the `error` field on `turn_done`. So `franklin -p ...` exited 1 with completely empty stderr, which is how the 400s above stayed hidden. Now the classified error + tip get printed before the non-zero exit.

## Out of scope (gateway-side)

- `gpt-5.3-codex` → `HTTP 503: Streaming not supported for Responses API models`. Now visible (thanks to #4), but the fix is in the gateway's Responses-API stream path.
- `anthropic/claude-sonnet-4.6` / `zai/glm-5.1` intermittent `fetch failed`. Reproduced locally and by cheetah. Hypothesis: long first-token latency + Cloud Run/Cloudflare resetting the still-empty downstream HTTP/2 stream. Suggested fix is a heartbeat SSE comment at the start of each gateway stream entry point (Bedrock + GLM-OpenAI-compatible + Anthropic transpile). I can file this separately against blockrun.

## Test plan

- [x] `franklin start -p \"say PONG\" -m openai/gpt-5-mini` → returns PONG
- [x] Same for gpt-5-nano, gpt-5.4, gpt-5.5
- [x] Same for xai/grok-3, xai/grok-4-0709, xai/grok-4-1-fast-reasoning
- [x] `anthropic/claude-sonnet-4.6` regression — still returns PONG
- [x] Headless `-p` mode now prints the classified error to stderr on failure (verified via grok-3 reproducing the 400 before fix #2 was applied)
- [x] `npm run build` clean