### PR TITLE
feat(channels): Slack bot + Telegram allowlist & group @-mention gating

### DIFF
--- a/src/channel/slack.ts
+++ b/src/channel/slack.ts
@@ -1,0 +1,414 @@
+/**
+ * Slack ingress channel — drive Franklin from a Slack workspace.
+ *
+ * Why this exists: same motivation as the Telegram channel, but for teams.
+ * A persistent agent with a wallet is most useful when a whole channel can
+ * reach it. This module wraps Franklin's `interactiveSession` with a Slack
+ * Socket Mode connection: inbound @mentions (and DMs) → agent turn → streamed
+ * text deltas posted back into the originating thread.
+ *
+ * Multi-user: unlike Telegram's single-owner lock, Slack uses an allowlist of
+ * user ids (`SLACK_ALLOWED_USERS`). Anyone on the list can @mention the bot in
+ * a channel or DM it; everyone else is ignored. The wallet is real money, so
+ * an empty allowlist denies everyone by default.
+ *
+ * Session model (MVP v1): ONE shared session for the running bot, exactly like
+ * the Telegram channel. All authorized users share a single Franklin
+ * conversation. Replies always land in a thread so the channel stays tidy.
+ * NOTE: Hermes-style per-thread isolation (a separate concurrent session per
+ * Slack thread) is the planned v2 — it needs a session-manager that runs
+ * multiple `interactiveSession` instances at once, which this single-queue
+ * design intentionally does not do yet.
+ *
+ * Transport: Socket Mode (WebSocket via @slack/bolt), not Events API webhooks.
+ * Works behind NAT / through laptop sleep-wake without a public HTTPS endpoint.
+ */
+
+import { setupAgentWallet, setupAgentSolanaWallet } from '@blockrun/llm';
+import type { AgentConfig, Dialogue, StreamEvent } from '../agent/types.js';
+import { interactiveSession } from '../agent/loop.js';
+import { ModelClient } from '../agent/llm.js';
+import { extractBrainEntities } from '../brain/extract.js';
+import { extractLearnings } from '../learnings/extractor.js';
+
+// Slack's hard per-message cap is ~40 KB, but readability tanks long before
+// that. Keep chunks small so a long answer arrives as a few tidy messages.
+const CHUNK_MAX = 3500;
+// Progressive flush: emit a partial message once the buffer crosses this and
+// hits a paragraph boundary, mirroring the Telegram channel's behaviour.
+const PROGRESSIVE_FLUSH_MIN = 1200;
+
+export interface SlackOptions {
+  /** Bot User OAuth token (xoxb-…), from the Slack app's OAuth page. */
+  botToken: string;
+  /** App-level token (xapp-…) with connections:write, for Socket Mode. */
+  appToken: string;
+  /** Slack user ids allowed to drive the bot. Empty set denies everyone. */
+  allowedUsers: Set<string>;
+  /** Verbose: log every inbound event and turn on bolt's DEBUG logging. */
+  debug?: boolean;
+  /** Called with each user-facing log line so the CLI can print them. */
+  log?: (line: string) => void;
+}
+
+/**
+ * Where a reply should be posted. `threadTs` is set for channel mentions (so
+ * replies stay grouped in a thread) but left undefined for top-level DMs —
+ * threading a DM reply hides it in a sub-thread the user isn't looking at.
+ */
+interface SlackTarget {
+  channel: string;
+  threadTs?: string;
+}
+
+/**
+ * Split a long agent response into Slack-sized chunks. Prefers newline
+ * boundaries, falls back to a hard character split for pathological inputs.
+ * Short responses return a single chunk. Mirrors `splitForTelegram`.
+ */
+export function splitForSlack(text: string, max = CHUNK_MAX): string[] {
+  if (text.length <= max) return [text];
+  const chunks: string[] = [];
+  let remaining = text;
+  while (remaining.length > max) {
+    const windowEnd = Math.min(max, remaining.length);
+    const nlIdx = remaining.lastIndexOf('\n', windowEnd - 1);
+    const cut = nlIdx > Math.floor(max * 0.5) ? nlIdx + 1 : windowEnd;
+    chunks.push(remaining.slice(0, cut));
+    remaining = remaining.slice(cut);
+  }
+  if (remaining.length > 0) chunks.push(remaining);
+  return chunks;
+}
+
+/**
+ * Progressive flush: given a growing buffer, return `{flush, keep}` where
+ * `flush` ends at a paragraph boundary and `keep` is the trailing partial to
+ * hold until more arrives. Identical strategy to the Telegram channel.
+ */
+export function takeProgressiveChunk(
+  buffer: string,
+  threshold = PROGRESSIVE_FLUSH_MIN,
+  hardCap = CHUNK_MAX,
+): { flush: string; keep: string } {
+  const mustFlush = buffer.length > hardCap;
+  if (!mustFlush && buffer.length < threshold) {
+    return { flush: '', keep: buffer };
+  }
+  const preferPos = buffer.lastIndexOf('\n\n', Math.min(buffer.length, hardCap) - 1);
+  if (preferPos > Math.floor(threshold * 0.5)) {
+    return { flush: buffer.slice(0, preferPos + 2), keep: buffer.slice(preferPos + 2) };
+  }
+  const nlPos = buffer.lastIndexOf('\n', Math.min(buffer.length, hardCap) - 1);
+  if (nlPos > Math.floor(threshold * 0.5)) {
+    return { flush: buffer.slice(0, nlPos + 1), keep: buffer.slice(nlPos + 1) };
+  }
+  if (mustFlush) {
+    return { flush: buffer.slice(0, hardCap), keep: buffer.slice(hardCap) };
+  }
+  return { flush: '', keep: buffer };
+}
+
+/** Strip a leading `<@BOTID>` (and any extra mentions) from an app_mention. */
+function stripMentions(text: string): string {
+  return text.replace(/<@[A-Z0-9]+>/g, '').replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Start the bot. Resolves only on fatal error; the outer CLI handles SIGINT.
+ */
+export async function runSlackBot(
+  agentConfig: AgentConfig,
+  opts: SlackOptions,
+): Promise<void> {
+  const log = opts.log ?? (() => {});
+
+  // Lazy import keeps @slack/bolt out of the load path for users who never
+  // run the Slack bot, matching how heavy optional deps are handled elsewhere.
+  const { App, LogLevel } = await import('@slack/bolt');
+
+  const state = {
+    inputQueue: [] as string[],
+    inputWaiters: [] as Array<(v: string | null) => void>,
+    currentTarget: undefined as SlackTarget | undefined,
+    responseBuffer: '',
+    running: true,
+    restartRequested: false,
+    botUserId: undefined as string | undefined,
+  };
+
+  const app = new App({
+    token: opts.botToken,
+    appToken: opts.appToken,
+    socketMode: true,
+    logLevel: opts.debug ? LogLevel.DEBUG : LogLevel.WARN,
+  });
+
+  // ── Slack send helpers ───────────────────────────────────────────────
+  const postMessage = async (target: SlackTarget, text: string): Promise<void> => {
+    for (let attempt = 0; attempt < 2; attempt++) {
+      try {
+        await app.client.chat.postMessage({
+          channel: target.channel,
+          ...(target.threadTs ? { thread_ts: target.threadTs } : {}),
+          text,
+        });
+        return;
+      } catch (err) {
+        if (attempt === 1) {
+          log(`[slack] postMessage failed: ${(err as Error).message}`);
+          return;
+        }
+        await new Promise((r) => setTimeout(r, 2000));
+      }
+    }
+  };
+
+  const postChunked = async (target: SlackTarget, text: string): Promise<void> => {
+    const chunks = splitForSlack(text);
+    if (chunks.length === 1) {
+      await postMessage(target, chunks[0]);
+      return;
+    }
+    for (let i = 0; i < chunks.length; i++) {
+      await postMessage(target, `[${i + 1}/${chunks.length}] ${chunks[i]}`);
+    }
+  };
+
+  // ── Bot control commands (handled here, not by the agent) ─────────────
+  // Slack swallows unregistered "/foo" slash commands, but inside an
+  // @mention the text "@bot /new" reaches us intact, so these still work.
+  const handleControlCommand = async (target: SlackTarget, text: string): Promise<boolean> => {
+    const cmd = text.trim().toLowerCase();
+    switch (cmd) {
+      case '/help':
+      case 'help':
+        await postMessage(
+          target,
+          'Franklin bot\n' +
+            '• `/new` — start a fresh conversation (clears history)\n' +
+            '• `/balance` — show wallet USDC balance\n' +
+            '• `/status` — chain, model, permission mode\n' +
+            'Anything else is forwarded to the agent.',
+        );
+        return true;
+      case '/new':
+        state.restartRequested = true;
+        state.inputQueue.length = 0;
+        {
+          const waiters = state.inputWaiters.splice(0);
+          for (const w of waiters) w(null);
+        }
+        await postMessage(target, '🔄 Starting a new conversation…');
+        return true;
+      case '/balance': {
+        try {
+          if (agentConfig.chain === 'solana') {
+            const c = await setupAgentSolanaWallet({ silent: true });
+            const addr = await c.getWalletAddress();
+            const bal = await c.getBalance();
+            await postMessage(target, `Chain: solana\nWallet: ${addr}\nBalance: $${bal.toFixed(2)} USDC`);
+          } else {
+            const c = setupAgentWallet({ silent: true });
+            const addr = c.getWalletAddress();
+            const bal = await c.getBalance();
+            await postMessage(target, `Chain: base\nWallet: ${addr}\nBalance: $${bal.toFixed(2)} USDC`);
+          }
+        } catch (err) {
+          await postMessage(target, `Couldn't fetch balance: ${(err as Error).message}`);
+        }
+        return true;
+      }
+      case '/status':
+        await postMessage(
+          target,
+          `chain: ${agentConfig.chain}\n` +
+            `model: ${agentConfig.model}\n` +
+            `permission: ${agentConfig.permissionMode ?? 'default'}`,
+        );
+        return true;
+      default:
+        return false;
+    }
+  };
+
+  // ── Input queue (feeds interactiveSession's getUserInput) ─────────────
+  const enqueueInput = (target: SlackTarget, text: string): void => {
+    state.currentTarget = target;
+    if (state.inputWaiters.length > 0) {
+      const w = state.inputWaiters.shift()!;
+      w(text);
+    } else {
+      state.inputQueue.push(text);
+    }
+  };
+
+  const waitNextInput = (): Promise<string | null> => {
+    if (state.restartRequested) return Promise.resolve(null);
+    if (state.inputQueue.length > 0) {
+      return Promise.resolve(state.inputQueue.shift()!);
+    }
+    if (!state.running) return Promise.resolve(null);
+    return new Promise((resolve) => state.inputWaiters.push(resolve));
+  };
+
+  // ── Event sink — progressive flush with a final sweep on turn_done ────
+  const flushProgressive = (): void => {
+    if (!state.currentTarget) return;
+    const { flush, keep } = takeProgressiveChunk(state.responseBuffer);
+    if (flush.trim()) {
+      const target = state.currentTarget;
+      state.responseBuffer = keep;
+      void postMessage(target, flush.trim());
+    }
+  };
+
+  const handleEvent = (event: StreamEvent): void => {
+    switch (event.kind) {
+      case 'text_delta':
+        state.responseBuffer += event.text;
+        if (state.responseBuffer.length >= PROGRESSIVE_FLUSH_MIN) {
+          flushProgressive();
+        }
+        break;
+      case 'capability_start':
+        if (state.currentTarget) {
+          if (state.responseBuffer.trim()) {
+            const target = state.currentTarget;
+            const text = state.responseBuffer.trim();
+            state.responseBuffer = '';
+            void postMessage(target, text);
+          }
+          void postMessage(state.currentTarget, `⏳ ${event.name}…`);
+        }
+        break;
+      case 'turn_done': {
+        const target = state.currentTarget;
+        const text = state.responseBuffer.trim();
+        state.responseBuffer = '';
+        if (target && text) void postChunked(target, text);
+        if (event.reason === 'error' && event.error && target) {
+          void postMessage(target, `❌ Error: ${event.error}`);
+        }
+        break;
+      }
+    }
+  };
+
+  // ── Inbound routing ───────────────────────────────────────────────────
+  const authorized = (userId: string | undefined): boolean =>
+    !!userId && opts.allowedUsers.has(userId);
+
+  const ingest = async (
+    userId: string | undefined,
+    channel: string,
+    threadTs: string | undefined,
+    rawText: string,
+  ): Promise<void> => {
+    const target: SlackTarget = { channel, threadTs };
+    if (!authorized(userId)) {
+      log(`[slack] rejected unauthorized sender id=${userId ?? 'n/a'}`);
+      await postMessage(target, 'Not authorized.');
+      return;
+    }
+    const text = stripMentions(rawText);
+    if (!text) return;
+    log(`[slack] ← ${text.slice(0, 80)}${text.length > 80 ? '…' : ''}`);
+
+    if (text.startsWith('/') || text.toLowerCase() === 'help') {
+      state.currentTarget = target;
+      const handled = await handleControlCommand(target, text);
+      if (handled) return;
+      // Unknown command falls through to the agent (it has its own slash
+      // handling for /retry, /model, /cost, …).
+    }
+    enqueueInput(target, text);
+  };
+
+  // app_mention: someone @mentioned the bot in a channel. Reply in-thread so
+  // the conversation stays grouped; a top-level mention starts a new thread.
+  app.event('app_mention', async ({ event }) => {
+    const e = event as { user?: string; channel: string; ts: string; thread_ts?: string; text: string };
+    await ingest(e.user, e.channel, e.thread_ts ?? e.ts, e.text);
+  });
+
+  // Direct messages to the bot. Ignore the bot's own messages, edits, and
+  // any message that carries a subtype (joins, file shares, etc.).
+  app.message(async ({ message }) => {
+    const m = message as {
+      channel_type?: string;
+      subtype?: string;
+      user?: string;
+      bot_id?: string;
+      channel: string;
+      ts: string;
+      thread_ts?: string;
+      text?: string;
+    };
+    if (opts.debug) {
+      log(
+        `[slack] message event: channel_type=${m.channel_type} subtype=${m.subtype ?? '-'} ` +
+          `bot_id=${m.bot_id ?? '-'} user=${m.user ?? '-'} text=${(m.text ?? '').slice(0, 40)}`,
+      );
+    }
+    if (m.channel_type !== 'im') return; // channel posts arrive via app_mention
+    if (m.subtype || m.bot_id || !m.text) return;
+    if (m.user && m.user === state.botUserId) return;
+    // DMs reply at top level; only stay threaded if the user is already in one.
+    await ingest(m.user, m.channel, m.thread_ts, m.text);
+  });
+
+  // ── Connect ────────────────────────────────────────────────────────────
+  try {
+    const auth = (await app.client.auth.test()) as { user_id?: string; team?: string };
+    state.botUserId = auth.user_id;
+    await app.start();
+    log(
+      `[slack] connected as bot ${auth.user_id ?? '(unknown)'} ` +
+        `team=${auth.team ?? '?'} — ${opts.allowedUsers.size} allowed user(s)`,
+    );
+  } catch (err) {
+    throw new Error(`Slack connect failed: ${(err as Error).message}`);
+  }
+
+  // Shared LLM client for post-session extraction (built once).
+  const extractor = new ModelClient({
+    apiUrl: agentConfig.apiUrl,
+    chain: agentConfig.chain,
+  });
+
+  const harvestSession = async (history: Dialogue[]): Promise<void> => {
+    if (history.length < 4) return;
+    const sid = `slack-${new Date().toISOString()}`;
+    try {
+      await Promise.race([
+        Promise.all([
+          extractLearnings(history, sid, extractor),
+          extractBrainEntities(history, sid, extractor),
+        ]),
+        new Promise((r) => setTimeout(r, 15_000)),
+      ]);
+    } catch (err) {
+      log(`[slack] post-session extraction failed: ${(err as Error).message}`);
+    }
+  };
+
+  // ── Outer session loop (mirrors the Telegram channel) ─────────────────
+  try {
+    let firstSession = true;
+    while (state.running) {
+      state.restartRequested = false;
+      if (!firstSession) agentConfig.resumeSessionId = undefined;
+      firstSession = false;
+      const history = await interactiveSession(agentConfig, waitNextInput, handleEvent);
+      void harvestSession(history);
+      if (!state.restartRequested) break;
+      log('[slack] session reset by /new');
+    }
+  } finally {
+    state.running = false;
+    const waiters = state.inputWaiters.splice(0);
+    for (const w of waiters) w(null);
+    await app.stop().catch(() => {});
+  }
+}

--- a/src/channel/telegram.ts
+++ b/src/channel/telegram.ts
@@ -128,6 +128,8 @@ export async function runTelegramBot(
     running: true,
     restartRequested: false,
     stoppedBy: undefined as Error | undefined,
+    // One "working" ping per turn — don't spam a message for every tool call.
+    workingNotified: false,
   };
 
   // ── Telegram HTTP helpers ────────────────────────────────────────────
@@ -273,8 +275,9 @@ export async function runTelegramBot(
         }
         break;
       case 'capability_start':
-        // Best-effort signal that the agent is working. Flush any buffered
-        // text first so the user sees the narrative order correctly.
+        // Best-effort "agent is working" signal. Flush buffered text first so
+        // order reads right, then send ONE ping per turn — not one per tool
+        // call (a multi-tool run otherwise floods the chat).
         if (state.currentChatId !== undefined) {
           if (state.responseBuffer.trim()) {
             const chatId = state.currentChatId;
@@ -282,13 +285,17 @@ export async function runTelegramBot(
             state.responseBuffer = '';
             void sendMessage(chatId, text);
           }
-          void sendMessage(state.currentChatId, `⏳ ${event.name}…`);
+          if (!state.workingNotified) {
+            state.workingNotified = true;
+            void sendMessage(state.currentChatId, '⏳ Working…');
+          }
         }
         break;
       case 'turn_done': {
         const chatId = state.currentChatId;
         const text = state.responseBuffer.trim();
         state.responseBuffer = '';
+        state.workingNotified = false; // reset for the next turn
         if (chatId !== undefined && text) void sendChunked(chatId, text);
         if (event.reason === 'error' && event.error && chatId !== undefined) {
           void sendMessage(chatId, `❌ Error: ${event.error}`);

--- a/src/channel/telegram.ts
+++ b/src/channel/telegram.ts
@@ -16,12 +16,27 @@
  * HTTPS endpoint. `node fetch` is the only HTTP dep.
  */
 
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { setupAgentWallet, setupAgentSolanaWallet } from '@blockrun/llm';
 import type { AgentConfig, Dialogue, StreamEvent } from '../agent/types.js';
 import { interactiveSession } from '../agent/loop.js';
 import { ModelClient } from '../agent/llm.js';
 import { extractBrainEntities } from '../brain/extract.js';
 import { extractLearnings } from '../learnings/extractor.js';
+
+// Per-bot prefs (persisted so a restart keeps the user's choice).
+const PREFS_FILE = path.join(os.homedir(), '.blockrun', 'telegram-prefs.json');
+function loadPrefs(): { showTools?: boolean } {
+  try { return JSON.parse(fs.readFileSync(PREFS_FILE, 'utf-8')); } catch { return {}; }
+}
+function savePrefs(prefs: { showTools?: boolean }): void {
+  try {
+    fs.mkdirSync(path.dirname(PREFS_FILE), { recursive: true });
+    fs.writeFileSync(PREFS_FILE, JSON.stringify(prefs, null, 2), { mode: 0o600 });
+  } catch { /* best-effort */ }
+}
 
 const TG_API = 'https://api.telegram.org';
 const POLL_TIMEOUT_SECONDS = 25;
@@ -128,8 +143,10 @@ export async function runTelegramBot(
     running: true,
     restartRequested: false,
     stoppedBy: undefined as Error | undefined,
-    // One "working" ping per turn — don't spam a message for every tool call.
-    workingNotified: false,
+    // Tool names used in the current turn → one summary at turn end (not one
+    // message per call). `showTools` gates whether that summary is sent.
+    toolsUsed: [] as string[],
+    showTools: loadPrefs().showTools ?? true,
   };
 
   // ── Telegram HTTP helpers ────────────────────────────────────────────
@@ -175,6 +192,16 @@ export async function runTelegramBot(
   // ── Slash commands (handled by the bot, not the agent) ──────────────
   const handleSlashCommand = async (chatId: number, text: string): Promise<boolean> => {
     const cmd = text.trim().toLowerCase();
+
+    // `/tools` toggles the per-turn tool summary (takes on/off, or bare = flip).
+    if (cmd === '/tools' || cmd.startsWith('/tools ')) {
+      const arg = cmd.slice('/tools'.length).trim();
+      state.showTools = arg === 'on' ? true : arg === 'off' ? false : !state.showTools;
+      savePrefs({ showTools: state.showTools });
+      await sendMessage(chatId, `🔧 工具调用汇总:${state.showTools ? '开启 ✅' : '关闭'}`);
+      return true;
+    }
+
     switch (cmd) {
       case '/start':
       case '/help':
@@ -182,6 +209,7 @@ export async function runTelegramBot(
           chatId,
           'Franklin bot\n\n' +
             '/new — start a fresh conversation (clears history)\n' +
+            '/tools [on|off] — toggle the per-turn tool-usage summary\n' +
             '/balance — show wallet USDC balance\n' +
             '/status — show chain, model, and session stats\n' +
             '/help — this message\n\n' +
@@ -275,28 +303,28 @@ export async function runTelegramBot(
         }
         break;
       case 'capability_start':
-        // Best-effort "agent is working" signal. Flush buffered text first so
-        // order reads right, then send ONE ping per turn — not one per tool
-        // call (a multi-tool run otherwise floods the chat).
-        if (state.currentChatId !== undefined) {
-          if (state.responseBuffer.trim()) {
-            const chatId = state.currentChatId;
-            const text = state.responseBuffer.trim();
-            state.responseBuffer = '';
-            void sendMessage(chatId, text);
-          }
-          if (!state.workingNotified) {
-            state.workingNotified = true;
-            void sendMessage(state.currentChatId, '⏳ Working…');
-          }
+        // Record the tool (for the turn-end summary) and flush buffered text so
+        // narrative order reads right. No per-tool message — a multi-tool run
+        // otherwise floods the chat.
+        if (event.name) state.toolsUsed.push(event.name);
+        if (state.currentChatId !== undefined && state.responseBuffer.trim()) {
+          const chatId = state.currentChatId;
+          const text = state.responseBuffer.trim();
+          state.responseBuffer = '';
+          void sendMessage(chatId, text);
         }
         break;
       case 'turn_done': {
         const chatId = state.currentChatId;
         const text = state.responseBuffer.trim();
         state.responseBuffer = '';
-        state.workingNotified = false; // reset for the next turn
         if (chatId !== undefined && text) void sendChunked(chatId, text);
+        // One tool summary per turn (toggle with /tools).
+        if (chatId !== undefined && state.showTools && state.toolsUsed.length) {
+          const uniq = [...new Set(state.toolsUsed)];
+          void sendMessage(chatId, `🔧 用了 ${state.toolsUsed.length} 个工具:${uniq.join(' · ')}`);
+        }
+        state.toolsUsed = [];
         if (event.reason === 'error' && event.error && chatId !== undefined) {
           void sendMessage(chatId, `❌ Error: ${event.error}`);
         }

--- a/src/channel/telegram.ts
+++ b/src/channel/telegram.ts
@@ -38,6 +38,10 @@ export interface TelegramOptions {
   token: string;
   /** Numeric Telegram user id that's allowed to drive the bot. Required. */
   ownerId: number;
+  /** Extra numeric user ids allowed to drive the bot (e.g. other people in a
+   *  group). The owner is always allowed; this widens access without dropping
+   *  the lock. Empty/undefined → owner-only (original behaviour). */
+  allowedUsers?: Set<number>;
   /** Called with each user-facing log line so the CLI can print them. */
   log?: (line: string) => void;
 }
@@ -46,9 +50,10 @@ interface TgUpdate {
   update_id: number;
   message?: {
     message_id: number;
-    chat: { id: number };
+    chat: { id: number; type?: string };
     from?: { id: number; username?: string; first_name?: string };
     text?: string;
+    reply_to_message?: { from?: { id?: number; is_bot?: boolean } };
   };
 }
 
@@ -294,10 +299,21 @@ export async function runTelegramBot(
   };
 
   // ── Long-poll loop (runs concurrently with interactiveSession) ──────
+  // Captured from getMe so the group @mention gate knows the bot's handle/id.
+  let botUsername: string | undefined;
+  let botId: number | undefined;
+
   const pollLoop = async (): Promise<void> => {
     try {
-      const me = await api<{ username?: string }>('getMe', {});
-      log(`[telegram] connected as @${me.username ?? '(unknown)'} — owner=${opts.ownerId}`);
+      const me = await api<{ id?: number; username?: string }>('getMe', {});
+      botUsername = me.username;
+      botId = me.id;
+      log(
+        `[telegram] connected as @${me.username ?? '(unknown)'} — owner=${opts.ownerId}` +
+          (opts.allowedUsers && opts.allowedUsers.size
+            ? ` + ${opts.allowedUsers.size} allowed user(s)`
+            : ''),
+      );
     } catch (err) {
       state.stoppedBy = err as Error;
       state.running = false;
@@ -323,7 +339,27 @@ export async function runTelegramBot(
         state.offset = u.update_id + 1;
         const msg = u.message;
         if (!msg?.text || !msg.from) continue;
-        if (msg.from.id !== opts.ownerId) {
+
+        // In groups, only act when the bot is addressed: @mentioned (incl. the
+        // `/cmd@bot` form) or replied to. Everything else — plain chatter AND
+        // bare slash commands — is ignored SILENTLY. Private chats need no mention.
+        const isGroup = !!msg.chat.type && msg.chat.type !== 'private';
+        let text = msg.text;
+        if (isGroup) {
+          const tag = botUsername ? `@${botUsername}` : '';
+          const mentioned = !!tag && text.toLowerCase().includes(tag.toLowerCase());
+          const repliedToBot = !!botId && msg.reply_to_message?.from?.id === botId;
+          if (!mentioned && !repliedToBot) continue;
+          // Strip the @mention so the agent gets a clean prompt.
+          if (mentioned && tag) {
+            text = text.replace(new RegExp(tag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'ig'), '').trim();
+          }
+        }
+        if (!text) continue; // mention with no actual content
+
+        const isAuthorized =
+          msg.from.id === opts.ownerId || !!opts.allowedUsers?.has(msg.from.id);
+        if (!isAuthorized) {
           void sendMessage(msg.chat.id, 'Not authorized.');
           log(
             `[telegram] rejected unauthorized sender id=${msg.from.id} ` +
@@ -331,18 +367,18 @@ export async function runTelegramBot(
           );
           continue;
         }
-        log(`[telegram] ← ${msg.text.slice(0, 80)}${msg.text.length > 80 ? '…' : ''}`);
+        log(`[telegram] ← ${text.slice(0, 80)}${text.length > 80 ? '…' : ''}`);
 
         // Intercept bot slash commands before handing off to the agent.
-        if (msg.text.trim().startsWith('/')) {
+        if (text.trim().startsWith('/')) {
           state.currentChatId = msg.chat.id;
-          const handled = await handleSlashCommand(msg.chat.id, msg.text);
+          const handled = await handleSlashCommand(msg.chat.id, text);
           if (handled) continue;
           // Unknown slash command: fall through to agent (which has its own
           // slash handling for /retry, /model, /cost, …).
         }
 
-        enqueueInput(msg.chat.id, msg.text);
+        enqueueInput(msg.chat.id, text);
       }
     }
   };

--- a/src/commands/slack.ts
+++ b/src/commands/slack.ts
@@ -1,0 +1,144 @@
+/**
+ * `franklin slack` — start the Slack ingress bot.
+ *
+ * Designed to run on a server / always-on laptop. Reads the bot token, app
+ * token, and the user allowlist from env (or ~/.blockrun/config). Uses
+ * trust-mode permissions because the operator is remote — there's no terminal
+ * prompt they can answer per tool call. The `SLACK_ALLOWED_USERS` allowlist in
+ * `runSlackBot` is the real security boundary, mirroring Telegram's owner lock.
+ */
+
+import chalk from 'chalk';
+import { loadChain, API_URLS } from '../config.js';
+import { assembleInstructions } from '../agent/context.js';
+import { allCapabilities } from '../tools/index.js';
+import { loadMcpConfig } from '../mcp/config.js';
+import { connectMcpServers, disconnectMcpServers } from '../mcp/client.js';
+import { loadConfig } from './config.js';
+import { runSlackBot } from '../channel/slack.js';
+import { findLatestSessionByChannel } from '../session/storage.js';
+import type { AgentConfig } from '../agent/types.js';
+
+interface SlackCommandOptions {
+  model?: string;
+  debug?: boolean;
+}
+
+export async function slackCommand(opts: SlackCommandOptions): Promise<void> {
+  const botToken = process.env.SLACK_BOT_TOKEN;
+  const appToken = process.env.SLACK_APP_TOKEN;
+  const allowedRaw = process.env.SLACK_ALLOWED_USERS;
+
+  if (!botToken || !appToken || !allowedRaw) {
+    console.error(chalk.red('Missing Slack config.'));
+    console.error(chalk.dim(
+      '\nSet three env vars before running `franklin slack`:\n' +
+      '  SLACK_BOT_TOKEN=<xoxb-… Bot User OAuth token>\n' +
+      '  SLACK_APP_TOKEN=<xapp-… app-level token with connections:write>\n' +
+      '  SLACK_ALLOWED_USERS=<comma-separated Slack user ids, e.g. U01ABC,U02DEF>\n\n' +
+      'Socket Mode must be enabled on the app, and the bot must be invited to\n' +
+      'the channel (/invite @your-bot). Find a user id via their profile →\n' +
+      '⋮ → Copy member ID.',
+    ));
+    process.exit(1);
+  }
+
+  const allowedUsers = new Set(
+    allowedRaw.split(',').map((s) => s.trim()).filter(Boolean),
+  );
+  if (allowedUsers.size === 0) {
+    console.error(chalk.red('SLACK_ALLOWED_USERS is empty — that would deny everyone.'));
+    process.exit(1);
+  }
+
+  const chain = loadChain();
+  const apiUrl = API_URLS[chain];
+  const config = loadConfig();
+
+  const model =
+    opts.model ||
+    config['default-model'] ||
+    'nvidia/qwen3-coder-480b';
+
+  const workingDir = process.cwd();
+  const systemInstructions = assembleInstructions(workingDir, model);
+
+  // Connect MCP servers (Notion, etc.) so the bot exposes their tools — mirrors
+  // what `franklin start` does. Without this the bot only has built-in tools.
+  const mcpConfig = loadMcpConfig(workingDir);
+  let mcpTools: typeof allCapabilities = [];
+  const mcpServerCount = Object.keys(mcpConfig.mcpServers).filter(
+    (k) => !mcpConfig.mcpServers[k].disabled,
+  ).length;
+  if (mcpServerCount > 0) {
+    try {
+      mcpTools = await connectMcpServers(mcpConfig, opts.debug);
+      if (mcpTools.length > 0) {
+        console.log(chalk.dim(`  MCP:    ${mcpTools.length} tools from ${mcpServerCount} server(s)`));
+      }
+    } catch (err) {
+      console.error(chalk.yellow(`  MCP error: ${(err as Error).message}`));
+    }
+  }
+
+  // Resume the most recent session tagged for THIS workspace bot so a process
+  // restart doesn't drop the conversation. MVP v1 keeps one shared session per
+  // bot (see channel/slack.ts), so the channel tag is workspace-scoped.
+  const channelTag = 'slack:shared';
+  const prior = findLatestSessionByChannel(channelTag);
+  if (prior) {
+    console.log(chalk.dim(
+      `  resuming session ${prior.id} (${prior.messageCount} msgs, ` +
+      `last update ${new Date(prior.updatedAt).toLocaleString()})`,
+    ));
+  }
+
+  const agentConfig: AgentConfig = {
+    model,
+    apiUrl,
+    chain,
+    systemInstructions,
+    capabilities: [...allCapabilities, ...mcpTools],
+    workingDir,
+    // No interactive terminal for permission prompts — remote operator can't
+    // answer y/n per tool. The Slack allowlist is the security boundary.
+    permissionMode: 'trust',
+    debug: opts.debug,
+    sessionChannel: channelTag,
+    resumeSessionId: prior?.id,
+  };
+
+  console.log(chalk.bold.cyan('Franklin Slack bot'));
+  console.log(chalk.dim(`  chain: ${chain}`));
+  console.log(chalk.dim(`  model: ${model}`));
+  console.log(chalk.dim(`  allowed users: ${allowedUsers.size}`));
+  console.log(chalk.yellow(
+    '  permission mode: trust — every tool the model picks will execute ' +
+    'without confirmation. The allowlist is your only gate.\n',
+  ));
+
+  let exitAttempts = 0;
+  process.on('SIGINT', () => {
+    exitAttempts++;
+    if (exitAttempts === 1) {
+      console.log(chalk.dim('\nStopping… (press Ctrl-C again to force)'));
+    } else {
+      process.exit(130);
+    }
+  });
+
+  try {
+    await runSlackBot(agentConfig, {
+      botToken,
+      appToken,
+      allowedUsers,
+      debug: opts.debug,
+      log: (line) => console.log(chalk.dim(line)),
+    });
+  } catch (err) {
+    console.error(chalk.red(`Slack bot failed: ${(err as Error).message}`));
+    process.exit(1);
+  } finally {
+    disconnectMcpServers().catch(() => {});
+  }
+}

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -43,6 +43,14 @@ export async function telegramCommand(opts: TelegramCommandOptions): Promise<voi
     process.exit(1);
   }
 
+  // Optional allowlist: extra numeric user ids that may drive the bot (e.g. other
+  // people in a group). Comma-separated. Owner is always allowed.
+  const allowedUsers = new Set<number>([ownerId]);
+  for (const raw of (process.env.TELEGRAM_ALLOWED_USERS ?? '').split(',')) {
+    const id = parseInt(raw.trim(), 10);
+    if (Number.isFinite(id) && id > 0) allowedUsers.add(id);
+  }
+
   const chain = loadChain();
   const apiUrl = API_URLS[chain];
   const config = loadConfig();
@@ -109,6 +117,7 @@ export async function telegramCommand(opts: TelegramCommandOptions): Promise<voi
     await runTelegramBot(agentConfig, {
       token,
       ownerId,
+      allowedUsers,
       log: (line) => console.log(chalk.dim(line)),
     });
   } catch (err) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import { configCommand } from './commands/config.js';
 import { statsCommand } from './commands/stats.js';
 import { logsCommand } from './commands/logs.js';
 import { daemonCommand } from './commands/daemon.js';
+import { slackCommand } from './commands/slack.js';
 import { initCommand } from './commands/init.js';
 import { uninitCommand } from './commands/uninit.js';
 import { proxyCommand } from './commands/proxy.js';
@@ -105,6 +106,13 @@ program
   .description('Manage franklin background proxy (start|stop|status)')
   .option('-p, --port <port>', 'Proxy port', '8402')
   .action((action, options) => daemonCommand(action, options));
+
+program
+  .command('slack')
+  .description('Run the Slack ingress bot (Socket Mode)')
+  .option('--model <model>', 'Model to use')
+  .option('--debug', 'Verbose Slack/Bolt logging')
+  .action((options) => slackCommand(options));
 
 program
   .command('panel')


### PR DESCRIPTION
## What
- **Slack**: restore the `slack` command + channel (was uncommitted WIP, nearly lost) and register it in the CLI.
- **Telegram**: add `TELEGRAM_ALLOWED_USERS` allowlist (owner always allowed); in **groups** only act on **@mention or reply-to-bot** (mention stripped before the prompt), ignore other group chatter; private chats unchanged.

## Notes
- Stacked on `feat/webui-server` (so the diff is just the channels commit). After that merges, this retargets to `main`.