### PR TITLE
docs(readme): link back to blockrun.ai/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,6 +500,10 @@ Same wallet. Same tools. From your phone.
 
 ## Documentation
 
+Full BlockRun docs: **https://blockrun.ai/docs**
+
+- [Agent developer guide](https://blockrun.ai/docs/getting-started/agent-developers) — building agents on BlockRun
+- [Models, SDKs & APIs](https://blockrun.ai/docs) — the full gateway reference
 - [Plugin SDK guide](docs/plugin-sdk.md) — build your own workflow vertical
 - [Changelog](CHANGELOG.md) — every release explained
 - [Roadmap](docs/ROADMAP.md) — what's coming next


### PR DESCRIPTION
Adds a public docs link-back to the existing **Documentation** section of the README.

Previously the section only referenced internal `docs/` paths. This integrates the public docs site so readers can reach the full gateway reference:

- Full BlockRun docs: https://blockrun.ai/docs
- Agent developer guide: https://blockrun.ai/docs/getting-started/agent-developers
- Models, SDKs & APIs: https://blockrun.ai/docs

No other content changed. Internal `docs/` links are left intact.