### PR TITLE
Close 5 more single-command bypasses from convergence verify (3.29.13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Franklin Agent 3.29.13 — close 5 more single-command bypasses from the 3.29.12 convergence verify (round-8)
+
+A second 13-agent convergence verify confirmed **5 NEW single-command bypass classes** the round-7 fixes didn't anticipate — one critical (a fresh evasion of the wallet directory rule itself). All fixed; benign controls preserved.
+
+- **`rtk <cmd>` wildcard exec (HIGH).** The guard blanket-allowed `rtk` (a CLI proxy) as a leaf command, so `rtk node evil.js` auto-approved arbitrary code execution and `rtk git config core.pager …` re-opened the round-7 git-config hole when wrapped. rtk is a command *rewriter* — its safety equals the **wrapped** command's. The guard now strips the `rtk`/`rtk proxy` prefix and recurses (like `time`/`nice`); read-only meta-commands (`gain`/`discover`/`--version`) stay safe.
+- **Empty-quote / backslash / ANSI-C splice on the wallet key (CRITICAL).** `cat ~/.block''run/.sess''ion` read the EVM private key: the shell strips `''`/`""`/`\` before opening the file, but the literal `.blockrun`/basename regexes saw non-contiguous text. The guard now matches every deny pattern against a **normalized copy** that mimics the shell's quote/escape removal, and treats ANSI-C (`$'\x6e'`) / locale (`$"…"`) quoting as opaque. Closes the same splice on all four wallet-key basenames (`.session`, `.solana-session`, `.solana-session-key2`, `solana-wallet.json`).
+- **Broadened credential-store reads (HIGH).** Round-7's denylist missed many plaintext secret stores that a bare `cat` would dump into context: `~/.git-credentials`, `~/.config/gh/hosts.yml`, `~/.cargo/credentials.toml`, `~/.config/rclone/rclone.conf`, **`~/.config/solana/id.json`** (a spendable Solana CLI keypair), macOS keychain, and shell-history files. All now prompt.
+- **`git branch -d` / `git tag -d` ref destruction (LOW).** Delete/rename/copy/force-move forms of `branch`/`tag` auto-approved via the read-only subcommand allowlist (only `branch -D` was caught). Their ref-destroying flags now prompt; read and **create** forms stay safe.
+
+The recurring lesson stands: text-classifying shell commands for auto-approval is a denylist treadmill. The canonicalized `isWalletKeyPath` guard on the file/media tools remains the primary wallet protection; the bash-guard is the best-effort shell net and now fails toward prompting on quoting, expansion, wrappers, and anything else it can't statically resolve. New regression tests pin all five classes plus the benign controls. Verified: local suite 504/504.
+
 ## Franklin Agent 3.29.12 — close the 6 single-command bypasses from the 3.29.11 convergence verify (round-7)
 
 An 8-agent adversarial convergence verify of the 3.29.11 guards confirmed **6 more single-command holes** — two critical. Each was traced through the real classifier and reproduced before fixing. The unifying principle this round: a bash segment is only auto-approved ("safe") when its **full effect is statically visible** — any runtime indirection the classifier can't see now forces a prompt.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockrun/franklin",
-  "version": "3.29.12",
+  "version": "3.29.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockrun/franklin",
-      "version": "3.29.12",
+      "version": "3.29.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@blockrun/llm": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockrun/franklin",
-  "version": "3.29.12",
+  "version": "3.29.13",
   "description": "Franklin Agent — The AI agent with a wallet. Spends USDC autonomously to get real work done. Pay per action, no subscriptions.",
   "type": "module",
   "exports": {

--- a/src/agent/bash-guard.ts
+++ b/src/agent/bash-guard.ts
@@ -171,24 +171,38 @@ export function classifyBashRisk(command: string): BashRiskResult {
 }
 
 function isSegmentSafe(segment: string): boolean {
+  // The shell strips quotes and backslash-escapes BEFORE opening a path, so a
+  // sensitive filename can be spliced to dodge a literal regex: `.block''run`,
+  // `.block"run"`, `'.blockrun'`, `.\blockrun` all resolve to `.blockrun` at the
+  // OS but read as non-contiguous text to a regex. Match the DENY patterns below
+  // against a normalized copy that mimics the shell's quote/escape removal, so no
+  // quoting arrangement of a wallet/secret path can reach 'safe'. (Over-matching
+  // here only ever prompts — it never blocks.)
+  const norm = segment.replace(/\\(.)/g, '$1').replace(/['"]/g, '');
+
   // Never auto-approve a command that touches the wallet key store. Matching the
-  // FILENAME is hopeless — it's trivially obfuscated (`.solana""-session`,
-  // `.\solana-session`, a glob, or an unlisted key file like
-  // solana-wallet-key2.json). So match the DIRECTORY: any reference to
-  // ~/.blockrun forces a prompt. (The file Read/Write/Edit tools have a separate
-  // canonicalized guard; this is the best-effort net for the shell. Over-
-  // prompting on a stray `.blockrun` path is fine — it prompts, never blocks.)
-  if (/\.blockrun/i.test(segment)) {
+  // FILENAME is hopeless — it's trivially obfuscated. So match the DIRECTORY: any
+  // reference to ~/.blockrun forces a prompt. (The file Read/Write/Edit tools
+  // have a separate canonicalized guard; this is the best-effort net for the shell.)
+  if (/\.blockrun/i.test(norm)) {
     return false;
   }
   // Relative reads with no `.blockrun` in the text (e.g. the cwd is the wallet
   // dir): match the known key/secret basenames broadly (any *wallet*.json/.key).
-  if (/(?<![\w-])(?:\.solana-session(?:-key2)?|\.session|[\w-]*wallet[\w-]*\.(?:json|key))(?![\w-])/i.test(segment)) {
+  if (/(?<![\w-])(?:\.solana-session(?:-key2)?|\.session|[\w-]*wallet[\w-]*\.(?:json|key))(?![\w-])/i.test(norm)) {
     return false;
   }
   // Command/process substitution runs an arbitrary INNER command the classifier
   // can't see (`echo $(node evil)`, `cat <(touch x)`) — never safe.
   if (/\$\(|`|<\(|>\(/.test(segment)) {
+    return false;
+  }
+  // ANSI-C (`$'\x6e'`) and locale (`$"..."`) quoting decode/expand to text the
+  // classifier can't resolve — and which the dequote pass above can't statically
+  // evaluate (`~/.blockru$'\x6e'/.session` → `~/.blockrun/.session`). Match it as
+  // an OPENING quote (at a token boundary) or by its tell-tale escape (`$'\`), so
+  // a `grep 'foo$'` regex anchor — a `$` before a CLOSING quote — is left safe.
+  if (/(?:^|[\s=(:,])\$['"]|\$['"]\\/.test(segment)) {
     return false;
   }
   // Parameter expansion (`$VAR`, `${VAR}`) expands to text the classifier also
@@ -203,7 +217,7 @@ function isSegmentSafe(segment: string): boolean {
   // A glob/brace in an explicit PATH (a token rooted at ~, ., or /) expands AFTER
   // this guard and can reach the wallet store (`cat ~/.b*/.s*`) or a sensitive
   // file. Bare cwd globs (`*.md`, `src/*.ts`) have no such prefix and stay safe.
-  if (/(?:^|\s)(?:~|\.|\/)\S*[*?[{]/.test(segment)) {
+  if (/(?:^|\s)(?:~|\.|\/)\S*[*?[{]/.test(norm)) {
     return false;
   }
   // Output redirection to a FILE target is a write — block it for EVERY segment,
@@ -218,10 +232,19 @@ function isSegmentSafe(segment: string): boolean {
   // dangerous-path block so `cat ~/.ssh/id_rsa`, `cat ~/.aws/credentials`,
   // `cat ~/.gnupg/secring.gpg`, gcloud tokens, `.npmrc`/`.pgpass`/`.netrc`, and
   // docker registry creds don't auto-approve secrets into model context.
-  if (/(?:^|[\s/~'"=])\.(?:ssh|aws|gnupg|kube)(?:\/|$|['"\s])/i.test(segment)) return false;
-  if (/\bid_(?:rsa|dsa|ecdsa|ed25519)\b/i.test(segment)) return false;
-  if (/(?:^|[\s/~'"=])\.(?:npmrc|pgpass|netrc)(?:$|['"\s])/i.test(segment)) return false;
-  if (/gcloud\/(?:credentials|access_tokens|application_default)|\.docker\/config/i.test(segment)) return false;
+  if (/(?:^|[\s/~=])\.(?:ssh|aws|gnupg|kube)(?:\/|$|\s)/i.test(norm)) return false;
+  if (/\bid_(?:rsa|dsa|ecdsa|ed25519)\b/i.test(norm)) return false;
+  if (/(?:^|[\s/~=])\.(?:npmrc|pgpass|netrc)(?:$|\s)/i.test(norm)) return false;
+  if (/gcloud\/(?:credentials|access_tokens|application_default)|\.docker\/config/i.test(norm)) return false;
+  // Other plaintext credential / key stores a bare `cat` would dump into context.
+  // Denylists lag the real set of secret files, so be generous — over-prompting
+  // is safe. Includes the Solana CLI default keypair (`~/.config/solana/id.json`),
+  // a SPENDABLE wallet that lives outside Franklin's own ~/.blockrun store.
+  if (/(?:^|[\s/~=])\.git-credentials(?:$|\s)/i.test(norm)) return false;
+  if (/(?:^|[\s/~=])\.(?:bash|zsh|sh|python|node_repl|mysql|psql|irb)_history(?:$|\s)/i.test(norm)) return false;
+  if (/(?:git|gh)\/(?:credentials|hosts\.ya?ml|hosts\.json)\b/i.test(norm)) return false;
+  if (/\.cargo\/credentials|rclone\/rclone\.conf|(?:^|[\s/~=])\.config\/solana(?:\/|\b)|solana\/id\.json/i.test(norm)) return false;
+  if (/(?:keychain(?:-db)?|\.keychain)\b|\bKeychains\/|\blogins\.json\b/i.test(norm)) return false;
 
   // Parse into words. An env-assignment PREFIX (`FOO=bar cmd …`) is a real
   // assignment only in the LEADING run before the command word — a later `x=y`
@@ -275,6 +298,16 @@ function isSegmentSafe(segment: string): boolean {
     if (subCmd === 'remote' && /(?:^|\s)(?:add|set-url|set-head|set-branches|remove|rm|rename|prune|update)\b/.test(segment)) {
       return false;
     }
+    // `branch`/`tag` read by default, but their delete/rename/copy/force flags
+    // silently mutate refs (lose local commits). `branch -D` is already a
+    // dangerous-pattern; gate the rest (incl. lowercase `-d`, `-m`, `-f`) here.
+    // Creating a branch/tag (a bare positional) stays safe — only ref destruction prompts.
+    if (subCmd === 'branch' && /(?:^|\s)-(?:d|D|m|M|c|C|f)\b|(?:^|\s)--(?:delete|move|copy|force|unset-upstream)\b/.test(segment)) {
+      return false;
+    }
+    if (subCmd === 'tag' && /(?:^|\s)-(?:d|f)\b|(?:^|\s)--(?:delete|force)\b/.test(segment)) {
+      return false;
+    }
     return true;
   }
 
@@ -290,8 +323,20 @@ function isSegmentSafe(segment: string): boolean {
     return SAFE_CARGO_SUBCOMMANDS.has(subCmd);
   }
 
-  // rtk (RTK wrapper — safe, it's a proxy)
-  if (baseName === 'rtk') return true;
+  // rtk is a command REWRITER/executor, not a leaf command: `rtk <cmd>` runs
+  // <cmd> (e.g. `rtk git status`), and `rtk proxy <cmd>` runs it unfiltered. So
+  // its safety equals the WRAPPED command's — a blanket allow turned it into a
+  // wildcard exec hole (`rtk node evil.js` auto-approved RCE). Strip the `rtk`
+  // token (and a `proxy` passthrough) and recurse, like the time/nice prefix.
+  // Read-only meta-subcommands (gain/discover/version) stay safe.
+  if (baseName === 'rtk') {
+    const next = words[argIdx] || '';
+    if (next === '' || next === 'gain' || next === 'discover' || /^-/.test(next)) return true;
+    const restWords = words.slice(next === 'proxy' ? argIdx + 1 : argIdx);
+    const rest = restWords.join(' ').trim();
+    if (!rest) return true;
+    return isSegmentSafe(rest);
+  }
 
   // `find` is read-only EXCEPT its action predicates, which execute arbitrary
   // commands or delete files (`find / -name id_rsa -exec cat {} +`, `find . -delete`).

--- a/test/local.mjs
+++ b/test/local.mjs
@@ -10465,3 +10465,83 @@ test('isBlockedSsrfHost blocks cloud-metadata HOSTNAMES + NAT64, allows public',
   for (const h of ['example.com', 'api.github.com', 'metadata-service.example.com'])
     assert.equal(isBlockedSsrfHost(h), false, `${h} (public) must be allowed`);
 });
+
+// ─── Round-8: the 5 NEW classes from the 3.29.12 convergence verify ──────────
+test('bash-guard: rtk is a command wrapper — safety equals the WRAPPED command', async () => {
+  const { classifyBashRisk } = await import('../dist/agent/bash-guard.js');
+  const safe = (c) => classifyBashRisk(c).level === 'safe';
+  // `rtk <cmd>` runs <cmd>; a blanket allow was a wildcard exec hole. Recurse instead.
+  for (const c of [
+    'rtk node evil.js',                            // arbitrary RCE (was auto-approved)
+    'rtk python3 evil.py',
+    'rtk bash evil.sh',
+    'rtk proxy bash evil.sh',                      // proxy = unfiltered exec passthrough
+    'rtk git config core.pager "node evil.js"',    // re-opened the git-config-write hole when wrapped
+    "rtk cat ~/.blockrun/.session",                // wallet read through the wrapper
+  ]) assert.equal(safe(c), false, `${c} must prompt`);
+  // Wrapping a genuinely-safe command stays safe; rtk meta-commands stay safe.
+  assert.equal(safe('rtk git status'), true);
+  assert.equal(safe('rtk git log --oneline'), true);
+  assert.equal(safe('rtk gain'), true);
+  assert.equal(safe('rtk discover'), true);
+  assert.equal(safe('rtk --version'), true);
+});
+
+test('bash-guard: empty-quote-splice + ANSI-C cannot smuggle a wallet-key read past the guard', async () => {
+  const { classifyBashRisk } = await import('../dist/agent/bash-guard.js');
+  const safe = (c) => classifyBashRisk(c).level === 'safe';
+  // The shell strips '' / "" / backslash before opening the file; the classifier
+  // now normalizes the same way so the spliced path still matches .blockrun/basenames.
+  for (const c of [
+    "cat ~/.block''run/.sess''ion",                // EVM key (critical)
+    'cat ~/.block""run/.sess""ion',                // double-quote variant
+    "cat ~/.block''run/.solana''-session",         // Solana key
+    "cat ~/.block''run/.solana''-session-key2",
+    "cat ~/.block''run/solana-w''allet.json",      // legacy wallet file
+    "head -c 99 ~/.bl\\ockrun/.session",           // backslash-escape splice
+    "cat ~/.blockru$'\\x6e'/.session",             // ANSI-C hex → 'n' mid-path
+    "cat '.blockrun'/.solana-session",             // whole-token quoting
+  ]) assert.equal(safe(c), false, `${c} must prompt`);
+  // A non-key file whose name merely contains a fragment stays safe.
+  assert.equal(safe('cat config.session.log'), true);
+  assert.equal(safe('cat README.md'), true);
+});
+
+test('bash-guard: broadened credential stores (git-credentials, gh hosts, cargo/rclone/Solana CLI, keychain, history) prompt', async () => {
+  const { classifyBashRisk } = await import('../dist/agent/bash-guard.js');
+  const safe = (c) => classifyBashRisk(c).level === 'safe';
+  for (const c of [
+    'cat ~/.git-credentials',                      // plaintext git push tokens
+    'cat ~/.config/git/credentials',
+    'cat ~/.config/gh/hosts.yml',                  // GitHub OAuth token
+    'cat ~/.cargo/credentials.toml',               // crates.io token
+    'cat ~/.config/rclone/rclone.conf',            // cloud-storage secrets
+    'cat ~/.config/solana/id.json',                // Solana CLI keypair (spendable wallet)
+    'cat ~/.zsh_history',                           // pasted secrets
+    'cat ~/.bash_history',
+    'cat ~/Library/Keychains/login.keychain-db',
+  ]) assert.equal(safe(c), false, `${c} must prompt`);
+  assert.equal(safe('cat package.json'), true, 'a normal json read stays safe');
+  assert.equal(safe('cat src/config/solana-helper.ts'), true, 'a project source file (no dot-config/solana path) is unaffected');
+});
+
+test('bash-guard: git branch/tag ref destruction prompts; read + create forms stay safe', async () => {
+  const { classifyBashRisk } = await import('../dist/agent/bash-guard.js');
+  const safe = (c) => classifyBashRisk(c).level === 'safe';
+  for (const c of [
+    'git branch -d feature-x',
+    'git branch -D feature-x',
+    'git branch -m old new',                        // rename (can clobber main)
+    'git branch -f main origin/main',               // force-move ref (loses local commits)
+    'git tag -d v1.0.0',
+    'git tag -f v1 HEAD',                           // force-clobber tag
+  ]) assert.equal(safe(c), false, `${c} must prompt`);
+  // Read + create forms stay auto-safe (creation is not destructive).
+  assert.equal(safe('git branch'), true);
+  assert.equal(safe('git branch -a'), true);
+  assert.equal(safe('git branch --show-current'), true);
+  assert.equal(safe('git branch newfeature'), true, 'creating a branch is safe');
+  assert.equal(safe('git tag'), true);
+  assert.equal(safe('git tag -l'), true);
+  assert.equal(safe('git tag v1.2.3'), true, 'creating a tag is safe');
+});


### PR DESCRIPTION
## Round-8 — second convergence verify

A second 13-agent adversarial convergence verify of the 3.29.12 guards confirmed **5 NEW single-command bypass classes** the round-7 fixes didn't anticipate. Each was traced through the real classifier and reproduced before fixing.

| Sev | Bypass | Fix |
|-----|--------|-----|
| 🟠 HIGH | `rtk node evil.js` — `rtk` wrapper blanket-allowed any wrapped command (wildcard RCE) | strip `rtk`/`rtk proxy` prefix and **recurse**; safety = wrapped command's |
| 🔴 CRITICAL | `cat ~/.block''run/.sess''ion` — empty-quote / backslash / ANSI-C splice reads the EVM key | deny patterns now run on a **shell-normalized** copy; `$'…'`/`$"…"` treated as opaque |
| 🟠 HIGH | `cat ~/.git-credentials` — denylist missed gh hosts, cargo/rclone, **Solana CLI keypair**, keychain, shell history | broadened credential-store denylist |
| 🟡 LOW | `git branch -d` / `git tag -d` — ref destruction via read-only allowlist | delete/rename/force flags prompt; read + create stay safe |

(The critical splice defeats the wallet **directory** rule itself — the shell strips `''`/`""`/`\` before opening the file, but the literal regex saw non-contiguous text. Fixed by matching against a dequoted/unescaped normalization that mimics shell tokenization.)

**The recurring lesson:** text-classifying shell commands for auto-approval is a denylist treadmill. `isWalletKeyPath` on the file/media tools is the primary wallet guard; bash-guard is the best-effort shell net and now fails toward prompting on quoting, expansion, wrappers, and anything it can't statically resolve.

Regression tests pin all five classes plus benign controls (wrapped-safe rtk, regex anchors, branch/tag create+list, project source files). **Local suite 504/504.**