### PR TITLE
chore: enable Renovate (shared org preset)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>blockrunai/renovate-config"]
+}


### PR DESCRIPTION
Enables Renovate by extending the shared org preset (`github>blockrunai/renovate-config`): weekly grouped minor/patch updates, auto-merged dev dependency updates and security PRs, and manual review for major version bumps. This config is inert until the Mend Renovate app is installed on the org, so merging it has no immediate effect beyond opting Franklin into the shared policy.