### PR TITLE
fix(tokens): one token-limit table for CLI and proxy; catalog fills gaps only

### DIFF
--- a/src/agent/optimize.ts
+++ b/src/agent/optimize.ts
@@ -10,6 +10,7 @@
  */
 
 import type { Dialogue, ContentPart, UserContentPart, TextSegment, ImageSegment } from './types.js';
+import { peekGatewayModel, warmGatewayModelsCache } from '../gateway-models.js';
 import { estimateTokens } from './tokens.js';
 
 // ─── Constants ─────────────────────────────────────────────────────────────
@@ -73,9 +74,21 @@ const MODEL_MAX_OUTPUT: Record<string, number> = {
   'qwen/qwen3.7-max': 65_536,
 };
 
-/** Get max output tokens for a model */
+/**
+ * Get max output tokens for a model.
+ *
+ * The static table above wins. The gateway catalog is consulted only for
+ * models with no entry — its own max_output values are demonstrably wrong for
+ * models we do have knowledge of (it reports 8192 for claude-haiku-4.5, which
+ * Anthropic documents as 64000), so it is a gap-filler, not a source of truth.
+ */
 export function getMaxOutputTokens(model: string): number {
-  return MODEL_MAX_OUTPUT[model] ?? 16_384;
+  const known = MODEL_MAX_OUTPUT[model];
+  if (known) return known;
+  const live = peekGatewayModel(model)?.max_output;
+  if (live && live > 0) return live;
+  warmGatewayModelsCache();
+  return 16_384;
 }
 
 /** Idle gap (minutes) after which old tool results are cleared.

--- a/src/agent/tokens.ts
+++ b/src/agent/tokens.ts
@@ -5,6 +5,7 @@
  */
 
 import type { Dialogue, ContentPart, UserContentPart } from './types.js';
+import { peekGatewayModel, warmGatewayModelsCache } from '../gateway-models.js';
 
 const DEFAULT_BYTES_PER_TOKEN = 4;
 
@@ -295,7 +296,20 @@ const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
  * Get the context window size for a model, with a conservative default.
  */
 export function getContextWindow(model: string): number {
+  // The static table wins. It is not merely a cache of the gateway catalog —
+  // several entries are deliberate DOWNGRADES from what the gateway advertises
+  // (see the Anthropic block above: the gateway reports 1M, but its 1M beta
+  // header is not enabled, so anything over 200k 413s). Letting the catalog
+  // override these would reintroduce the exact bug those comments prevent.
   if (MODEL_CONTEXT_WINDOWS[model]) return MODEL_CONTEXT_WINDOWS[model];
+  // No static entry — a live catalog value beats the blind default below.
+  // This is the qwen3.7-max class: a real model nobody has catalogued yet,
+  // which would otherwise silently compact at 128k.
+  const live = peekGatewayModel(model)?.context_window;
+  if (live && live > 0) return live;
+  // Cache is cold. Kick a fetch (deduped in-flight, errors swallowed) so the
+  // next call in this session gets a real number instead of the blind default.
+  warmGatewayModelsCache();
   // Pattern-based inference for unknown models
   if (model.includes('gemini')) return 1_000_000;
   if (model.includes('claude')) return 200_000;

--- a/src/gateway-models.ts
+++ b/src/gateway-models.ts
@@ -84,6 +84,38 @@ export function clearGatewayModelsCache(): void {
   inflight = null;
 }
 
+/**
+ * Synchronous, cache-only lookup. Returns null when the catalog has never been
+ * fetched in this process — it never triggers a fetch, so it is safe to call
+ * from the hot path and from sync functions like getContextWindow().
+ *
+ * Deliberately ignores the TTL: a stale gateway record still beats no record
+ * at all, and the only callers are fallbacks for models we have no static
+ * entry for. Callers must treat the static tables as authoritative — the
+ * gateway's own metadata is not reliable (verified 2026-07-20: it reports
+ * max_output 8192 for claude-haiku-4.5, which Anthropic documents as 64000,
+ * and 64000 for claude-sonnet-4.6, documented as 128000). It is also not
+ * enforced: Franklin sends max_tokens 16384 to haiku today and the gateway
+ * accepts it. Treat this as "better than a blind default", nothing more.
+ */
+export function peekGatewayModel(id: string): GatewayModel | null {
+  if (!cache) return null;
+  return cache.models.find(m => m.id === id) ?? null;
+}
+
+/** Test helper — seed the cache without a network call. */
+export function __primeGatewayModelsCache(models: GatewayModel[]): void {
+  cache = { models, expiresAt: Date.now() + CACHE_TTL_MS };
+}
+
+/**
+ * Fire-and-forget catalog warm. Populates the cache so the sync peek above has
+ * something to read. Errors are swallowed — every caller has a static fallback.
+ */
+export function warmGatewayModelsCache(): void {
+  void getGatewayModels().catch(() => { /* fallbacks cover this */ });
+}
+
 // ─── Fetch ──────────────────────────────────────────────────────────────
 
 async function doFetch(): Promise<GatewayModel[]> {

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -32,6 +32,7 @@ import {
   type RoutingProfile,
 } from '../router/index.js';
 import { estimateCost } from '../pricing.js';
+import { getMaxOutputTokens } from '../agent/optimize.js';
 import { VERSION } from '../config.js';
 
 // User-Agent for backend requests
@@ -383,13 +384,11 @@ export function createProxy(options: ProxyOptions): http.Server {
 
             {
               const original = parsed.max_tokens;
-              const model = (parsed.model || '').toLowerCase();
-              const modelCap =
-                model.includes('deepseek') ||
-                model.includes('haiku') ||
-                model.includes('gpt-oss')
-                  ? 8192
-                  : 16384;
+              // Was a hardcoded substring ladder (deepseek|haiku|gpt-oss → 8192,
+              // everything else → 16384) that ignored MODEL_MAX_OUTPUT entirely,
+              // so proxy users got a 16K ceiling on models the CLI already knew
+              // could emit 65K+ (Kimi K3, GPT-5.6 Sol). Same table both paths now.
+              const modelCap = getMaxOutputTokens(parsed.model || '');
 
               // Use max of (last output × 2, default 4096) capped by model limit
               // This ensures short replies don't starve the next request

--- a/test/local.mjs
+++ b/test/local.mjs
@@ -6698,6 +6698,71 @@ test('qwen3.7-max: paid aliases resolve, and bare `qwen` stays free', async () =
     'bare `qwen` must keep resolving to a $0 model');
 });
 
+// ─── gateway catalog as a GAP-FILLER, never an override ───────────────────
+//
+// The static tables are authoritative. Several entries are deliberate
+// DOWNGRADES from what the gateway advertises (Anthropic models are pinned to
+// 200k because the gateway's 1M beta header is not enabled — see tokens.ts).
+// And the gateway's own numbers are demonstrably wrong for models we do know:
+// verified live 2026-07-20, it reports max_output 8192 for claude-haiku-4.5,
+// which Anthropic documents as 64000. So: static first, catalog only for ids
+// we have no entry for.
+
+test('gateway catalog never overrides a static context-window entry', async () => {
+  const { getContextWindow } = await import('../dist/agent/tokens.js');
+  const { clearGatewayModelsCache, peekGatewayModel } = await import('../dist/gateway-models.js');
+  clearGatewayModelsCache();
+  // Anthropic models are deliberately pinned below the advertised 1M.
+  assert.equal(getContextWindow('anthropic/claude-opus-4.8'), 200_000,
+    'the 1M the gateway advertises must not win — >200k 413s at the gateway edge');
+  assert.equal(getContextWindow('anthropic/claude-sonnet-5'), 200_000);
+  assert.equal(peekGatewayModel('anything'), null, 'cold cache peeks to null, never fetches');
+});
+
+test('gateway catalog never overrides a static max-output entry', async () => {
+  const { getMaxOutputTokens } = await import('../dist/agent/optimize.js');
+  const { clearGatewayModelsCache } = await import('../dist/gateway-models.js');
+  clearGatewayModelsCache();
+  assert.equal(getMaxOutputTokens('anthropic/claude-haiku-4.5'), 16_384,
+    'static entry wins over the gateway\'s (wrong) 8192');
+  assert.equal(getMaxOutputTokens('moonshot/kimi-k3'), 65_536);
+});
+
+test('gateway catalog fills the gap for an uncatalogued model', async () => {
+  // The qwen3.7-max class: a real paid model with no static entry, which would
+  // otherwise compact at 128k and cap output at 16k.
+  const { getContextWindow } = await import('../dist/agent/tokens.js');
+  const { getMaxOutputTokens } = await import('../dist/agent/optimize.js');
+  const { clearGatewayModelsCache, __primeGatewayModelsCache } = await import('../dist/gateway-models.js');
+  clearGatewayModelsCache();
+  __primeGatewayModelsCache([
+    { id: 'someprovider/unknown-1', name: 'x', billing_mode: 'paid', categories: ['chat'],
+      context_window: 500_000, max_output: 32_768, pricing: { input: 1, output: 2 } },
+  ]);
+  assert.equal(getContextWindow('someprovider/unknown-1'), 500_000);
+  assert.equal(getMaxOutputTokens('someprovider/unknown-1'), 32_768);
+  // Still no override of a known id, even with the catalog warm.
+  assert.equal(getContextWindow('anthropic/claude-opus-4.8'), 200_000);
+  clearGatewayModelsCache();
+});
+
+test('proxy max-token cap uses the same table as the agent loop', async () => {
+  // Regression: the proxy carried its own substring ladder (deepseek|haiku|
+  // gpt-oss -> 8192, else 16384) that ignored MODEL_MAX_OUTPUT, so proxy users
+  // got 16k on models the CLI already knew could emit 65k+ (Kimi K3 at 65536,
+  // GPT-5.6 Sol at 128000). Both paths read one table now.
+  const { readFileSync } = await import('node:fs');
+  const src = readFileSync(new URL('../src/proxy/server.ts', import.meta.url), 'utf8');
+  assert.ok(src.includes('getMaxOutputTokens(parsed.model'),
+    'proxy must derive its cap from getMaxOutputTokens');
+  assert.ok(!src.includes("model.includes('gpt-oss')"),
+    'the hardcoded substring ladder must be gone from the proxy');
+
+  const { getMaxOutputTokens } = await import('../dist/agent/optimize.js');
+  assert.equal(getMaxOutputTokens('moonshot/kimi-k3'), 65_536);
+  assert.equal(getMaxOutputTokens('openai/gpt-5.6-sol'), 128_000);
+});
+
 // ─── picker trim (v3.9.3) ─────────────────────────────────────────────────
 
 test('picker trim: hidden entries are gone from the visible list', async () => {


### PR DESCRIPTION
## What

Two token-limit paths disagreed, and neither could learn about a model nobody had catalogued.

**The proxy had its own ladder.** `src/proxy/server.ts` capped `max_tokens` with a hardcoded substring chain — `deepseek|haiku|gpt-oss → 8192`, everything else `→ 16384` — that never consulted `MODEL_MAX_OUTPUT`. Proxy users were pinned at 16K on models the CLI already knew could emit far more: Kimi K3 (65,536) and GPT-5.6 Sol (128,000) were losing 4-8×. Both paths read `getMaxOutputTokens()` now.

**Nothing filled the gaps.** `getMaxOutputTokens()` and `getContextWindow()` now consult the live gateway catalog for ids with **no static entry** — the `qwen/qwen3.7-max` class, a real paid model that silently compacted at 128k and capped output at 16k until someone hand-added it.

## Why the catalog is a gap-filler and not the source of truth

This inverts the obvious design. `src/gateway-models.ts` says "Gateway is the single source of truth" in its header, so wiring it in as authoritative is the natural move. It's wrong, for two reasons — both verified against the live catalog on 2026-07-20:

**1. The gateway's numbers are wrong for models we already know.**

| model | Anthropic | gateway | Franklin |
|---|---|---|---|
| `claude-haiku-4.5` | 64,000 | **8,192** | 16,384 |
| `claude-sonnet-4.6` | 128,000 | **64,000** | 64,000 |
| `claude-opus-4.8` | 128,000 | 128,000 | 128,000 ✓ |

They're also not enforced — Franklin sends `max_tokens: 16384` to haiku today, comfortably above the advertised 8192, and the gateway accepts it. The field is unreliable metadata, not a contract.

**2. Where the gateway is right, we deliberately disagree.** Every Anthropic model is pinned to a 200k context window against the advertised 1M, because the gateway's 1M beta header is not enabled and anything larger 413s (`src/agent/tokens.ts:213-218`). Letting the catalog override would reintroduce exactly the bug that comment exists to prevent.

So: **static table wins; catalog only answers for ids we have never heard of.**

## How

- `peekGatewayModel(id)` — synchronous, cache-only, never fetches. Safe from the hot path and from sync functions.
- `warmGatewayModelsCache()` — fire-and-forget, kicked on the first static-table miss. No startup latency added; a cold or unreachable gateway degrades to exactly today's behavior.

## Left alone on purpose

`haiku-4.5` max output is 16,384 here vs Anthropic's documented 64,000, and `sonnet-4.6` is 64,000 vs 128,000. Both are under-estimates, not 400 risks. Raising them needs a real long-output run against a gateway whose metadata this PR just established is unreliable — separate change, separate verification.

## Tests

Four new tests pin the precedence in both directions: static entries survive a warm catalog, an uncatalogued id picks up the catalog's values, and the proxy ladder cannot come back.

**Local suite: 634 pass, 0 fail.**

## Gateway-side follow-ups (not in this PR)

- `max_output` is wrong for `claude-haiku-4.5` (8192 vs 64000) and `claude-sonnet-4.6` (64000 vs 128000).
- Upstream errors are swallowed. `qwen/qwen3.7-max` rejects `tool_choice` with `400 Invalid request: 400 Provider returned error`, naming nothing. Franklin's runtime retry keys on the error text mentioning `tool_choice`, so an opaque relay defeats it — v3.35.1 had to hardcode the model into a blocklist instead. Passing the provider's original message through would let the generic recovery work.