### PR TITLE
docs(tokens): correct the note claiming gateway max_output is unenforced

### DIFF
--- a/src/gateway-models.ts
+++ b/src/gateway-models.ts
@@ -94,9 +94,15 @@ export function clearGatewayModelsCache(): void {
  * entry for. Callers must treat the static tables as authoritative — the
  * gateway's own metadata is not reliable (verified 2026-07-20: it reports
  * max_output 8192 for claude-haiku-4.5, which Anthropic documents as 64000,
- * and 64000 for claude-sonnet-4.6, documented as 128000). It is also not
- * enforced: Franklin sends max_tokens 16384 to haiku today and the gateway
- * accepts it. Treat this as "better than a blind default", nothing more.
+ * and 64000 for claude-sonnet-4.6, documented as 128000).
+ *
+ * Correction to an earlier note here: those values are NOT inert metadata.
+ * The gateway clamps with them — Math.min(request.max_tokens, model.maxOutput)
+ * on both the messages and chat/completions handlers — and derives its price
+ * quote from the clamped ceiling. A request over the advertised cap is
+ * accepted rather than rejected, so the clamp is invisible until a reply is
+ * long enough to hit it, which is why a short smoke test looks fine.
+ * Treat this as "better than a blind default", nothing more.
  */
 export function peekGatewayModel(id: string): GatewayModel | null {
   if (!cache) return null;

--- a/src/gateway-models.ts
+++ b/src/gateway-models.ts
@@ -92,16 +92,20 @@ export function clearGatewayModelsCache(): void {
  * Deliberately ignores the TTL: a stale gateway record still beats no record
  * at all, and the only callers are fallbacks for models we have no static
  * entry for. Callers must treat the static tables as authoritative — the
- * gateway's own metadata is not reliable (verified 2026-07-20: it reports
- * max_output 8192 for claude-haiku-4.5, which Anthropic documents as 64000,
- * and 64000 for claude-sonnet-4.6, documented as 128000).
+ * gateway's own metadata has been wrong for models we already know. As of
+ * 2026-07-20 it reported max_output 8192 for claude-haiku-4.5 (Anthropic
+ * documents 64000) and 64000 for claude-sonnet-4.6 (documented 128000).
+ * Those two specific numbers are being corrected upstream, so do not treat
+ * them as current — the point that outlives them is that the catalog can be
+ * wrong, and a wrong value here is not cosmetic.
  *
- * Correction to an earlier note here: those values are NOT inert metadata.
+ * Correction to an earlier note here: these values are NOT inert metadata.
  * The gateway clamps with them — Math.min(request.max_tokens, model.maxOutput)
- * on both the messages and chat/completions handlers — and derives its price
- * quote from the clamped ceiling. A request over the advertised cap is
- * accepted rather than rejected, so the clamp is invisible until a reply is
- * long enough to hit it, which is why a short smoke test looks fine.
+ * in both the messages and chat/completions handlers — and derives its price
+ * quote from the clamped ceiling. An over-cap request is accepted rather than
+ * rejected: the handler logs "capping to <limit>" server-side and continues,
+ * so from here the clamp is invisible until a reply is long enough to hit it.
+ * That is why a short smoke test against a wrongly-capped model looks healthy.
  * Treat this as "better than a blind default", nothing more.
  */
 export function peekGatewayModel(id: string): GatewayModel | null {


### PR DESCRIPTION
Follow-up to #108. Comment-only, no behavior change.

The note I added in 3.35.2 said the gateway's `max_output` values are *"not enforced: Franklin sends max_tokens 16384 to haiku today and the gateway accepts it."*

Accepting the request and honoring it are different things. The gateway clamps with `Math.min(request.max_tokens, model.maxOutput)` on both the messages and chat/completions handlers, and derives its price quote from the clamped ceiling. The request is **accepted** rather than rejected, so the clamp stays invisible until a reply is long enough to hit it — the smoke test that produced my claim returned ten tokens, nowhere near either ceiling.

The rule the comment supports is unchanged and still correct: static tables stay authoritative, because the gateway's values are wrong for models we already know. Only the stated reason was wrong — and a wrong reason is how a right rule gets reverted by the next person who checks it.

Gateway-side fix for the underlying wrong values: BlockRunAI/blockrun#266.

Local suite 634 pass.