### PR TITLE
fix(tokens): gpt-5.5 and gpt-5.4 to 128000 — now actually measured

### DIFF
--- a/src/agent/optimize.ts
+++ b/src/agent/optimize.ts
@@ -53,11 +53,16 @@ const MODEL_MAX_OUTPUT: Record<string, number> = {
   'openai/gpt-5.6-sol': 128_000,
   'openai/gpt-5.6-terra': 128_000,
   'openai/gpt-5.6-luna': 128_000,
-  // 128000 is now measured, not read off the catalog. The earlier probe that
+  // 128000 is measured, not read off the catalog. The earlier probe that
   // seemed to refute it was invalid — both SDKs rejected max_tokens > 100000
   // client-side, so nothing reached a provider. Re-probed 2026-07-21 with that
-  // guard bypassed: both accept 128000, as did all 19 models advertising a
+  // guard bypassed: both accept 128000, as did every model advertising a
   // ceiling above 100000. The catalog was right; the measurement was broken.
+  //
+  // Franklin does not run that SDK guard on either request path — the agent
+  // loop and the proxy both use raw fetch and import only payment helpers from
+  // @blockrun/llm — so these values are independent of whether the SDK-side
+  // fix lands. (blockrun-llm#27 / blockrun-llm-ts#15, open at time of writing.)
   'openai/gpt-5.5': 128_000,
   'openai/gpt-5.4': 128_000,
   'openai/gpt-5.4-mini': 128_000,

--- a/src/agent/optimize.ts
+++ b/src/agent/optimize.ts
@@ -53,14 +53,13 @@ const MODEL_MAX_OUTPUT: Record<string, number> = {
   'openai/gpt-5.6-sol': 128_000,
   'openai/gpt-5.6-terra': 128_000,
   'openai/gpt-5.6-luna': 128_000,
-  // gpt-5.5 / gpt-5.4 stay at 32768. The catalog claims 128000 for both and
-  // that claim is UNREFUTED — an earlier attempt to verify it was invalid:
-  // both SDKs reject max_tokens > 100000 client-side (blockrun_llm
-  // validation.py:233, blockrun-llm-ts validation.ts:74), so the "rejections"
-  // collected at 128000 never reached a provider. Their real ceilings are
-  // unknown. Raising them needs a probe path that bypasses the SDK guard.
-  'openai/gpt-5.5': 32_768,
-  'openai/gpt-5.4': 32_768,
+  // 128000 is now measured, not read off the catalog. The earlier probe that
+  // seemed to refute it was invalid — both SDKs rejected max_tokens > 100000
+  // client-side, so nothing reached a provider. Re-probed 2026-07-21 with that
+  // guard bypassed: both accept 128000, as did all 19 models advertising a
+  // ceiling above 100000. The catalog was right; the measurement was broken.
+  'openai/gpt-5.5': 128_000,
+  'openai/gpt-5.4': 128_000,
   'openai/gpt-5.4-mini': 128_000,
   'openai/gpt-5.4-nano': 32_768,
   // Probed accepted at 65536 through the live gateway (2026-07-21) — a real

--- a/test/local.mjs
+++ b/test/local.mjs
@@ -6710,21 +6710,22 @@ test('anthropic max output matches the documented ceilings', async () => {
   assert.equal(getMaxOutputTokens('anthropic/claude-sonnet-4.6'), 128_000);
 });
 
-test('openai ceilings: one probed, two still unverified', async () => {
-  // gpt-5-mini was raised to 65536 on a real accepted request through the live
-  // gateway (2026-07-21). It is a FLOOR, not a proven ceiling — 65536 is also
-  // ESCALATED_MAX_TOKENS, so nothing here could tell a higher true limit apart.
+test('openai ceilings are measured, not read off the catalog', async () => {
+  // All three are now probed against the live gateway.
   //
-  // gpt-5.5 / gpt-5.4 stay at 32768. The catalog claims 128000 and that claim
-  // is UNREFUTED. An attempt to verify it was invalid: both SDKs reject
-  // max_tokens > 100000 client-side (blockrun_llm validation.py:233,
-  // blockrun-llm-ts validation.ts:74), so probes at 128000 never reached a
-  // provider — the "maximum: 100000" in those errors is an SDK constant, not
-  // an upstream response. Raising these needs a probe that bypasses the guard.
+  // gpt-5-mini  65536 accepted (probe was below the SDK guard, so it went out)
+  // gpt-5.5     128000 accepted, 2026-07-21, guard bypassed
+  // gpt-5.4     128000 accepted, same run
+  //
+  // An earlier pass recorded these as REJECTED at 128000 and concluded the
+  // catalog was wrong. That was measurement error: both SDKs threw on
+  // max_tokens > 100000 client-side, so 19 "rejections" never left the
+  // process. The uniform limit across three different providers was the tell.
+  // Fixed upstream in blockrun-llm#27 and blockrun-llm-ts#15.
   const { getMaxOutputTokens } = await import('../dist/agent/optimize.js');
+  assert.equal(getMaxOutputTokens('openai/gpt-5.5'), 128_000);
+  assert.equal(getMaxOutputTokens('openai/gpt-5.4'), 128_000);
   assert.equal(getMaxOutputTokens('openai/gpt-5-mini'), 65_536);
-  assert.equal(getMaxOutputTokens('openai/gpt-5.5'), 32_768);
-  assert.equal(getMaxOutputTokens('openai/gpt-5.4'), 32_768);
 });
 
 // ─── gateway catalog as a GAP-FILLER, never an override ───────────────────


### PR DESCRIPTION
| model | was | now |
|---|---|---|
| `openai/gpt-5.5` | 32,768 | **128,000** |
| `openai/gpt-5.4` | 32,768 | **128,000** |

## Why these moved twice

#111 raised them to 100,000 citing "upstream's stated maximum". I closed it: that number came from `blockrun_llm/validation.py:233`, a **client-side** guard, so the probe never reached a provider. #112 put them back at 32,768 and recorded the catalog's 128,000 as unrefuted but unverified.

Re-probed 2026-07-21 with the SDK guard bypassed in-process. Both accept **128,000** — as did all 19 models advertising a ceiling above 100,000, including `zai/glm-5.2` at 262,144. Zero rejections.

**The catalog was right the whole time. The measurement was broken.** Worth saying plainly, because the previous conclusion pointed the opposite way and this table is exactly where a wrong belief gets frozen.

Root cause fixed upstream: BlockRunAI/blockrun-llm#27 and BlockRunAI/blockrun-llm-ts#15 raise that guard from 100,000 to a 1,000,000 typo bound and reword the message so it no longer reads like a provider response.

## Effect

`CAPPED_MAX_TOKENS` is 16,384 and `ESCALATED_MAX_TOKENS` is 65,536, so a normal turn is unchanged. On a `max_tokens` stop the escalation ceiling goes from `min(65536, 32768) = 32768` to `min(65536, 128000) = 65536` — the recovery path doubles instead of being clamped back below where it started.

Local suite **636 pass, 0 fail.**