### PR TITLE
feat(wallet): Solana onramp + Solana as the default chain

### DIFF
--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -8,8 +8,9 @@ import {
 import { type Chain, saveChain } from '../config.js';
 
 export async function setupCommand(chainArg?: string) {
+  // Solana is the default chain; `franklin setup base` opts into Base.
   const chain: Chain =
-    chainArg === 'solana' ? 'solana' : 'base';
+    chainArg === 'base' ? 'base' : 'solana';
 
   if (chain === 'solana') {
     const wallets = scanSolanaWallets();

--- a/src/config.ts
+++ b/src/config.ts
@@ -45,9 +45,18 @@ export function loadChain(): Chain {
 
   try {
     const content = fs.readFileSync(CHAIN_FILE, 'utf-8').trim();
+    if (content === 'base') return 'base';
     if (content === 'solana') return 'solana';
-    return 'base';
-  } catch {
-    return 'base';
-  }
+  } catch { /* no explicit choice on disk — fall through to the default */ }
+
+  // Default chain is Solana. Exception: a Base wallet with no Solana wallet
+  // means the user funded before the default flipped — silently moving their
+  // spending to an empty Solana wallet would strand their USDC, so keep them
+  // on Base until they choose explicitly (`franklin solana`, panel switch,
+  // setup). Pure read — every path that creates the other wallet also calls
+  // saveChain, so the heuristic is only ever the pre-choice fallback.
+  // (.session / .solana-session are the SDK's wallet key files.)
+  const hasBaseWallet = fs.existsSync(path.join(BLOCKRUN_DIR, '.session'));
+  const hasSolanaWallet = fs.existsSync(path.join(BLOCKRUN_DIR, '.solana-session'));
+  return hasBaseWallet && !hasSolanaWallet ? 'base' : 'solana';
 }

--- a/src/onramp/client.ts
+++ b/src/onramp/client.ts
@@ -1,15 +1,19 @@
 /**
  * Coinbase Onramp link client.
  *
- * Exchanges the user's Base wallet address for a one-time Coinbase Onramp
- * URL via the BlockRun gateway. The gateway holds the CDP API key, signs the
- * JWT, and mints a single-use `sessionToken` (Coinbase requires Secure Init
- * since 2025-07-31 — plain appId URLs are deprecated). The returned URL is
- * one-time and expires in ~5 minutes, so it must be minted at click time and
- * never cached.
+ * Exchanges the user's wallet address for a one-time Coinbase Onramp URL via
+ * the BlockRun gateway of the active chain (Base → blockrun.ai, Solana →
+ * sol.blockrun.ai). The gateway holds the CDP API key, signs the JWT, and
+ * mints a single-use `sessionToken` (Coinbase requires Secure Init since
+ * 2025-07-31 — plain appId URLs are deprecated). The returned URL is one-time
+ * and expires in ~5 minutes, so it must be minted at click time and never
+ * cached.
  *
- * Base / USDC only. Mirrors the gateway-call pattern in src/phone/client.ts
- * and reuses the shared x402 POST helper.
+ * USDC only, on the active chain. The $0 x402 handshake doubles as wallet
+ * authentication — postWithPayment signs with the active chain's wallet, and
+ * the gateway binds the funding address to that signer. Mirrors the
+ * gateway-call pattern in src/phone/client.ts and reuses the shared x402 POST
+ * helper.
  */
 
 import { API_URLS, loadChain } from '../config.js';
@@ -21,23 +25,25 @@ export interface OnrampLinkResult {
 }
 
 /**
- * Mint a one-time Coinbase Onramp link that funds `address` (Base USDC).
- * Throws if the gateway is unreachable, not configured, or returns no URL.
+ * Mint a one-time Coinbase Onramp link that funds `address` with USDC on the
+ * active chain. Throws if the gateway is unreachable, not configured, or
+ * returns no URL.
  */
 export async function getOnrampUrl(address: string): Promise<OnrampLinkResult> {
-  // postWithPayment signs with the active chain's wallet; on Solana that
-  // would crash confusingly against this Base-only endpoint. Fail clearly.
-  if (loadChain() !== 'base') {
-    throw new Error('Onramp is Base-only — switch to Base to buy USDC with a card.');
-  }
-  const endpoint = `${API_URLS.base}/v1/onramp/token`;
+  const chain = loadChain();
+  const endpoint = `${API_URLS[chain]}/v1/onramp/token`;
   const result = await postWithPayment(
     endpoint,
-    { address, network: 'base', asset: 'USDC' },
+    { address, network: chain, asset: 'USDC' },
     'Mint a Coinbase Onramp session link to fund this wallet',
   );
 
   if (!result.ok) {
+    // A 404 means this gateway has not shipped the onramp route yet (gateway
+    // deploys are manual) — name the real situation instead of a bare status.
+    if (result.status === 404) {
+      throw new Error(`Onramp is not available on the ${chain} gateway yet — try again later.`);
+    }
     const msg = typeof result.body.error === 'string'
       ? result.body.error
       : `gateway ${result.status}`;

--- a/src/panel/html.ts
+++ b/src/panel/html.ts
@@ -1251,6 +1251,10 @@ async function loadWallet() {
     baseBtn.disabled = true;
     solanaBtn.disabled = true;
     note.textContent = 'Switching to ' + target + '…';
+    // The onramp status (e.g. a popup-blocked Coinbase link) belongs to the
+    // previous chain's wallet — a stale link would fund the wrong chain.
+    const onrampStatus = document.getElementById('wallet-onramp-status');
+    if (onrampStatus) onrampStatus.textContent = '';
     try {
       const r = await fetch('/api/chain', {
         method: 'POST',

--- a/src/panel/html.ts
+++ b/src/panel/html.ts
@@ -713,7 +713,7 @@ a:hover { text-decoration:underline; }
           <button class="btn btn-onramp" id="wallet-onramp-btn">&#128179;&nbsp; Buy USDC with card</button>
           <span class="wallet-import-status" id="wallet-onramp-status"></span>
         </div>
-        <p class="wallet-hint" id="wallet-onramp-hint">Powered by Coinbase Onramp &middot; Base only &middot; 60+ fiat currencies</p>
+        <p class="wallet-hint" id="wallet-onramp-hint">Powered by Coinbase Onramp &middot; 60+ fiat currencies</p>
       </div>
 
       <div class="card">
@@ -1207,12 +1207,8 @@ async function loadWallet() {
     solanaBtn.classList.toggle('active', w.chain === 'solana');
   }
 
-  // Coinbase Onramp is Base-only — hide the buy button + hint on Solana.
-  const onrampActions = document.getElementById('wallet-onramp-actions');
-  const onrampHint = document.getElementById('wallet-onramp-hint');
-  const onBase = w.chain === 'base';
-  if (onrampActions) onrampActions.style.display = onBase ? '' : 'none';
-  if (onrampHint) onrampHint.style.display = onBase ? '' : 'none';
+  // Coinbase Onramp works on both chains — the gateway of the active chain
+  // mints the link, so the buy button stays visible on Base and Solana alike.
 
   // QR via server — never leak address to third parties.
   // Encode chain + USDC token in the QR payload so wallet apps land

--- a/src/panel/server.ts
+++ b/src/panel/server.ts
@@ -352,21 +352,15 @@ export function createPanelServer(port: number): http.Server {
       // Mints a one-time Coinbase Onramp link to fund the wallet with a card.
       // Spends nothing locally, but it talks to the gateway with this wallet's
       // identity and opens a payment flow, so it gets the same loopback +
-      // same-origin posture as the wallet-mutating routes. Base only — the
-      // gateway mints a session token scoped to the Base address.
+      // same-origin posture as the wallet-mutating routes. The gateway of the
+      // active chain mints a session token scoped to that chain's address.
       if (p === '/api/wallet/onramp' && req.method === 'POST') {
         if (!isLocalPanelRequest(req)) {
           json(res, { error: 'forbidden' }, 403);
           return;
         }
         try {
-          const chain = loadChain();
-          if (chain !== 'base') {
-            json(res, { error: 'Onramp currently supports Base only — switch to Base to buy USDC with a card.' }, 400);
-            return;
-          }
-          const { setupAgentWallet } = await import('@blockrun/llm');
-          const address = setupAgentWallet({ silent: true }).getWalletAddress();
+          const address = await currentWalletAddress();
           const { getOnrampUrl } = await import('../onramp/client.js');
           const { url } = await getOnrampUrl(address);
           json(res, { url });

--- a/test/local.mjs
+++ b/test/local.mjs
@@ -189,6 +189,38 @@ test('oneShotExitCodeForTurnReason treats only completed turns as success', asyn
   assert.equal(oneShotExitCodeForTurnReason('aborted'), 1);
 });
 
+test('chain default: fresh installs resolve to solana; a lone legacy Base wallet stays on base', () => {
+  const fakeHome = mkdtempSync(join(tmpdir(), 'rc-chain-default-'));
+  const configUrl = new URL('../dist/config.js', import.meta.url).href;
+  const readChain = () => execFileSync(
+    process.execPath,
+    ['-e', `import(${JSON.stringify(configUrl)}).then(m => process.stdout.write(m.loadChain()))`],
+    { env: { ...process.env, HOME: fakeHome, RUNCODE_CHAIN: '' }, encoding: 'utf-8' },
+  );
+
+  try {
+    // Fresh install — no wallets, no saved choice → Solana.
+    assert.equal(readChain(), 'solana');
+
+    // Legacy user: a Base wallet exists but no Solana wallet and no explicit
+    // choice — flipping them to an empty Solana wallet would strand funded
+    // USDC, so they stay on Base.
+    mkdirSync(join(fakeHome, '.blockrun'), { recursive: true });
+    writeFileSync(join(fakeHome, '.blockrun', '.session'), '0xdeadbeef');
+    assert.equal(readChain(), 'base');
+
+    // Both wallets present without an explicit choice → the default wins.
+    writeFileSync(join(fakeHome, '.blockrun', '.solana-session'), 'deadbeef');
+    assert.equal(readChain(), 'solana');
+
+    // An explicit saved choice always beats the heuristic.
+    writeFileSync(join(fakeHome, '.blockrun', 'payment-chain'), 'base\n');
+    assert.equal(readChain(), 'base');
+  } finally {
+    rmSync(fakeHome, { recursive: true, force: true });
+  }
+});
+
 test('chain shortcut --help does not mutate saved chain or launch the agent', async () => {
   const fakeHome = mkdtempSync(join(tmpdir(), 'rc-chain-help-'));
   const chainFile = join(fakeHome, '.blockrun', 'payment-chain');


### PR DESCRIPTION
## Summary

Counterpart to [blockrun-sol#198](https://github.com/BlockRunAI/blockrun-sol/pull/198): the Solana gateway can now mint Coinbase Onramp session links, so Franklin unlocks card funding on Solana and flips the default chain to Solana.

## Onramp on both chains

- **`src/onramp/client.ts`** — drops the Base-only guard; targets `API_URLS[activeChain]` and passes `network: chain`. `postWithPayment` already signs the $0 x402 authentication with the active chain's wallet on both chains. A 404 from a gateway that hasn't shipped the route yet (gateway deploys are manual) surfaces as "Onramp is not available on the <chain> gateway yet" instead of a bare status.
- **`src/panel/server.ts`** — `POST /api/wallet/onramp` drops the chain gate and reuses `currentWalletAddress()` (chain-aware).
- **`src/panel/html.ts`** — the Buy-USDC button stays visible on Solana; hint no longer says "Base only".

## Solana as default

- **`src/config.ts`** — `loadChain()` with no explicit choice resolves to **solana**, with one migration exception: a Base wallet (`.session`) with no Solana wallet means the user funded before the flip — they stay on `base` so USDC is never silently stranded on an inactive chain. Pure read (the help/version no-mutation invariants hold); `RUNCODE_CHAIN` and the saved `payment-chain` file still win.
- **`src/commands/setup.ts`** — `franklin setup` now defaults to Solana; `franklin setup base` opts into Base.

## Tests

New `test/local.mjs` case pins the default-resolution matrix: fresh install → solana; lone legacy Base wallet → base; both wallets → solana; explicit saved choice always wins. Full suite: **648/648 pass**, build clean.

## Sequencing

Safe to merge before the gateway ships blockrun-sol#198 — until then the panel button on Solana shows the clear not-available-yet message rather than an error.