### PR TITLE
feat: preview Team workspace in Desktop

### DIFF
--- a/apps/desktop/src/components/FranklinChat.tsx
+++ b/apps/desktop/src/components/FranklinChat.tsx
@@ -7,7 +7,7 @@ import { useEffect, useRef, useState } from "react";
 import { ArrowUp, PanelLeft, ImageIcon, Clapperboard, Music, X, Plus, Check, ChevronDown, Gauge, BarChart3, TrendingUp, MoreHorizontal } from "lucide-react";
 import { TopBarMenu } from "./TopBarMenu";
 import { ModelSelect } from "./ModelSelect";
-import { HistorySidebar, type TryView } from "./HistorySidebar";
+import { HistorySidebar, type TryView, type WorkspaceMode } from "./HistorySidebar";
 import { MessageContent } from "./MessageContent";
 import { ActivitySummary } from "./ActivitySummary";
 import { MessageActions } from "./MessageActions";
@@ -19,6 +19,7 @@ import { GalleryPanel } from "./GalleryPanel";
 import { WalletPanel } from "./WalletPanel";
 import { SkillsPanel } from "./SkillsPanel";
 import { CLIPanel } from "./CLIPanel";
+import { TeamPanel } from "./TeamPanel";
 import { useFranklinChat } from "../hooks/use-franklin-chat";
 import { useChatHistory } from "../hooks/use-chat-history";
 import { useSpend } from "../hooks/use-spend";
@@ -75,6 +76,7 @@ export function FranklinChat() {
   const [lightbox, setLightbox] = useState<string | null>(null);
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const [view, setView] = useState<TryView>("chat");
+  const [workspaceMode, setWorkspaceMode] = useState<WorkspaceMode>("personal");
   const MOBILE_BP = 880;
   const closeSidebarOnMobile = () => {
     if (typeof window !== "undefined" && window.innerWidth <= MOBILE_BP) setSidebarOpen(false);
@@ -209,11 +211,13 @@ export function FranklinChat() {
         conversations={history.conversations}
         activeId={history.activeId}
         onNew={() => {
+          setWorkspaceMode("personal");
           history.newChat();
           setView("chat");
           closeSidebarOnMobile();
         }}
         onSelect={(id) => {
+          setWorkspaceMode("personal");
           history.selectChat(id);
           setView("chat");
           closeSidebarOnMobile();
@@ -225,6 +229,12 @@ export function FranklinChat() {
           closeSidebarOnMobile();
         }}
         open={sidebarOpen}
+        workspaceMode={workspaceMode}
+        onWorkspaceMode={(next) => {
+          setWorkspaceMode(next);
+          setView(next === "team" ? "team" : "chat");
+          closeSidebarOnMobile();
+        }}
         wallet={wallet}
       />
 
@@ -296,7 +306,9 @@ export function FranklinChat() {
           )}
         </div>
 
-        {view === "phone" ? (
+        {view === "team" ? (
+          <TeamPanel onPersonal={() => { setWorkspaceMode("personal"); setView("chat"); }} />
+        ) : view === "phone" ? (
           <PhonePanel />
         ) : view === "tools" ? (
           <ToolsPanel onTry={tryMarketplace} />

--- a/apps/desktop/src/components/HistorySidebar.tsx
+++ b/apps/desktop/src/components/HistorySidebar.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import {
   Plus, MessageSquare, Trash2, Phone, Blocks, Images, Wallet, Sparkles, Search,
-  Grid2x2, ChevronRight, Terminal,
+  Grid2x2, ChevronRight, Terminal, UsersRound, FolderKanban, BookOpen, Workflow,
 } from "lucide-react";
 import type { Conversation } from "../hooks/use-chat-history";
 import type { WalletInfo } from "../lib/wire";
@@ -10,7 +10,8 @@ import { MoreMenu } from "./MoreMenu";
 import { WalletPill } from "./WalletPill";
 import franklinAvatar from "../assets/franklin-avatar.png";
 
-export type TryView = "chat" | "phone" | "tools" | "gallery" | "wallet" | "skills" | "cli";
+export type TryView = "chat" | "phone" | "tools" | "gallery" | "wallet" | "skills" | "cli" | "team";
+export type WorkspaceMode = "personal" | "team";
 
 // Local bundled logo (no network → no offline blank).
 const PORTRAIT_URL = franklinAvatar;
@@ -24,12 +25,14 @@ interface Props {
   view: TryView;
   onView: (v: TryView) => void;
   open: boolean;
+  workspaceMode: WorkspaceMode;
+  onWorkspaceMode: (mode: WorkspaceMode) => void;
   /** Local CLI wallet (read-only) — replaces run's browser connect-wallet UI. */
   wallet: WalletInfo | null;
 }
 
-export function HistorySidebar({ conversations, activeId, onNew, onSelect, onDelete, view, onView, open, wallet }: Props) {
-  const { t } = useTryLang();
+export function HistorySidebar({ conversations, activeId, onNew, onSelect, onDelete, view, onView, open, workspaceMode, onWorkspaceMode, wallet }: Props) {
+  const { t, lang } = useTryLang();
   const [searchOpen, setSearchOpen] = useState(false);
   const [moreOpen, setMoreOpen] = useState(false);
   const moreBtnRef = useRef<HTMLButtonElement>(null);
@@ -54,17 +57,45 @@ export function HistorySidebar({ conversations, activeId, onNew, onSelect, onDel
     { key: "wallet", icon: <Wallet className="h-[18px] w-[18px]" />, label: t.wallet },
   ];
   const moreActive = moreNav.some((n) => n.key === view);
+  const teamCopy = lang === "zh"
+    ? { personal: "个人", team: "团队", home: "团队首页", chats: "共享对话", files: "共享文件", knowledge: "团队知识", workflows: "工作流", soon: "即将开放" }
+    : lang === "es"
+      ? { personal: "Personal", team: "Equipo", home: "Inicio del equipo", chats: "Conversaciones", files: "Archivos", knowledge: "Conocimiento", workflows: "Flujos", soon: "Próximamente" }
+      : { personal: "Personal", team: "Team", home: "Team home", chats: "Shared chats", files: "Shared files", knowledge: "Knowledge", workflows: "Workflows", soon: "Coming soon" };
+  const teamNav = [
+    { icon: <MessageSquare className="h-[18px] w-[18px]" />, label: teamCopy.chats },
+    { icon: <FolderKanban className="h-[18px] w-[18px]" />, label: teamCopy.files },
+    { icon: <BookOpen className="h-[18px] w-[18px]" />, label: teamCopy.knowledge },
+    { icon: <Workflow className="h-[18px] w-[18px]" />, label: teamCopy.workflows },
+  ];
 
   return (
     <>
     <aside className={`try-sidebar${open ? " is-open" : ""}`}>
-      <button className="try-brand" onClick={() => onView("chat")}>
+      <button className="try-brand" onClick={() => onWorkspaceMode("personal")}>
         <span className="try-brand-ring">
           <img src={PORTRAIT_URL} alt="Franklin" width={30} height={30} />
         </span>
         <span className="try-brand-name">Franklin</span>
       </button>
 
+      <div className="try-workspace-switch" aria-label="Workspace mode">
+        <button
+          className={workspaceMode === "personal" ? "is-active" : ""}
+          onClick={() => onWorkspaceMode("personal")}
+        >
+          {teamCopy.personal}
+        </button>
+        <button
+          className={workspaceMode === "team" ? "is-active" : ""}
+          onClick={() => onWorkspaceMode("team")}
+        >
+          <UsersRound className="h-3.5 w-3.5" />{teamCopy.team}<span>Beta</span>
+        </button>
+      </div>
+
+      {workspaceMode === "personal" ? (
+      <>
       <button className="try-nav-item" onClick={onNew}>
         <Plus className="h-[18px] w-[18px]" />
         {t.newChat}
@@ -130,6 +161,20 @@ export function HistorySidebar({ conversations, activeId, onNew, onSelect, onDel
         )}
       </div>
       </div>
+      </>
+      ) : (
+      <div className="try-scroll try-team-sidebar-content">
+        <button className="try-nav-item is-active" onClick={() => onView("team")}>
+          <UsersRound className="h-[18px] w-[18px]" />{teamCopy.home}<span className="try-nav-beta">Beta</span>
+        </button>
+        <div className="try-team-sidebar-label">{teamCopy.soon}</div>
+        {teamNav.map((item) => (
+          <button key={item.label} className="try-nav-item try-nav-disabled" disabled>
+            {item.icon}<span>{item.label}</span><span className="try-nav-soon">{teamCopy.soon}</span>
+          </button>
+        ))}
+      </div>
+      )}
 
       <div className="try-sidebar-footer">
         <div className="try-footer-icons">

--- a/apps/desktop/src/components/TeamPanel.tsx
+++ b/apps/desktop/src/components/TeamPanel.tsx
@@ -1,0 +1,144 @@
+import {
+  ArrowRight,
+  BookOpen,
+  Cloud,
+  FolderKanban,
+  LockKeyhole,
+  MessageSquareText,
+  ShieldCheck,
+  UsersRound,
+  Workflow,
+} from "lucide-react";
+import { useTryLang } from "../lib/i18n";
+
+const COPY = {
+  en: {
+    eyebrow: "Team workspace",
+    title: "One Franklin, shared with your team.",
+    body: "A shared place for conversations, files, knowledge, and repeatable agent workflows. The cloud workspace is still being prepared.",
+    preview: "Product preview",
+    localOnly: "Nothing is uploaded in this beta",
+    agent: "Team Agent",
+    agentBody: "A group conversation where teammates and Franklin work from the same context.",
+    composer: "Team conversations are coming soon",
+    personal: "Continue in Personal",
+    sharedChats: "Shared conversations",
+    sharedChatsBody: "Discuss, assign, and continue agent work together.",
+    files: "Shared files",
+    filesBody: "A permission-aware cloud workspace for team artifacts.",
+    knowledge: "Team knowledge",
+    knowledgeBody: "Reusable project context that Franklin can reference.",
+    workflows: "Team workflows",
+    workflowsBody: "Save and run repeatable agent processes with your team.",
+    comingSoon: "Coming soon",
+  },
+  zh: {
+    eyebrow: "团队工作区",
+    title: "一个 Franklin，和整个团队一起使用。",
+    body: "共享对话、文件、知识和可复用 Agent 工作流。云端团队空间仍在准备中。",
+    preview: "产品预览",
+    localOnly: "当前 Beta 不会上传任何内容",
+    agent: "Team Agent",
+    agentBody: "团队成员与 Franklin 在同一上下文中协作的群聊。",
+    composer: "团队对话即将开放",
+    personal: "继续使用个人模式",
+    sharedChats: "共享对话",
+    sharedChatsBody: "共同讨论、分配并继续 Agent 任务。",
+    files: "共享文件",
+    filesBody: "带权限管理的团队云端文件空间。",
+    knowledge: "团队知识",
+    knowledgeBody: "让 Franklin 可复用的项目背景和知识。",
+    workflows: "团队工作流",
+    workflowsBody: "保存并与团队运行可复用的 Agent 流程。",
+    comingSoon: "即将开放",
+  },
+  es: {
+    eyebrow: "Espacio de equipo",
+    title: "Un Franklin, compartido con todo tu equipo.",
+    body: "Conversaciones, archivos, conocimiento y flujos de agentes compartidos. El espacio en la nube sigue en preparación.",
+    preview: "Vista previa",
+    localOnly: "Nada se sube durante esta beta",
+    agent: "Agente del equipo",
+    agentBody: "Una conversación grupal donde el equipo y Franklin comparten el mismo contexto.",
+    composer: "Las conversaciones de equipo llegarán pronto",
+    personal: "Continuar en Personal",
+    sharedChats: "Conversaciones compartidas",
+    sharedChatsBody: "Comenta, asigna y continúa el trabajo del agente en equipo.",
+    files: "Archivos compartidos",
+    filesBody: "Un espacio en la nube con permisos para los archivos del equipo.",
+    knowledge: "Conocimiento del equipo",
+    knowledgeBody: "Contexto reutilizable que Franklin puede consultar.",
+    workflows: "Flujos de equipo",
+    workflowsBody: "Guarda y ejecuta procesos de agentes con tu equipo.",
+    comingSoon: "Próximamente",
+  },
+} as const;
+
+export function TeamPanel({ onPersonal }: { onPersonal: () => void }) {
+  const { lang } = useTryLang();
+  const c = COPY[lang] ?? COPY.en;
+  const features = [
+    { icon: <MessageSquareText />, title: c.sharedChats, body: c.sharedChatsBody },
+    { icon: <FolderKanban />, title: c.files, body: c.filesBody },
+    { icon: <BookOpen />, title: c.knowledge, body: c.knowledgeBody },
+    { icon: <Workflow />, title: c.workflows, body: c.workflowsBody },
+  ];
+
+  return (
+    <main className="try-team-panel">
+      <div className="try-team-inner">
+        <div className="try-team-hero">
+          <div className="try-team-eyebrow">
+            <UsersRound className="h-4 w-4" />
+            {c.eyebrow}
+            <span className="try-team-beta">Beta</span>
+          </div>
+          <h1>{c.title}</h1>
+          <p>{c.body}</p>
+          <div className="try-team-trust">
+            <ShieldCheck className="h-4 w-4" />
+            <span>{c.preview}</span>
+            <span className="try-team-trust-dot" />
+            <LockKeyhole className="h-4 w-4" />
+            <span>{c.localOnly}</span>
+          </div>
+        </div>
+
+        <section className="try-team-agent-preview">
+          <div className="try-team-agent-head">
+            <div className="try-team-avatar-stack" aria-hidden="true">
+              <span>F</span><span>A</span><span>M</span>
+            </div>
+            <div>
+              <h2>{c.agent}</h2>
+              <p>{c.agentBody}</p>
+            </div>
+            <span className="try-team-soon"><Cloud className="h-3.5 w-3.5" />{c.comingSoon}</span>
+          </div>
+          <div className="try-team-composer" aria-disabled="true">
+            <MessageSquareText className="h-4 w-4" />
+            <span>{c.composer}</span>
+            <button disabled aria-label={c.comingSoon}><ArrowRight className="h-4 w-4" /></button>
+          </div>
+        </section>
+
+        <section className="try-team-feature-grid">
+          {features.map((feature) => (
+            <article key={feature.title} className="try-team-feature">
+              <div className="try-team-feature-icon">{feature.icon}</div>
+              <div>
+                <h3>{feature.title}</h3>
+                <p>{feature.body}</p>
+              </div>
+              <span>{c.comingSoon}</span>
+            </article>
+          ))}
+        </section>
+
+        <button className="try-team-personal" onClick={onPersonal}>
+          {c.personal}<ArrowRight className="h-4 w-4" />
+        </button>
+      </div>
+    </main>
+  );
+}

--- a/apps/desktop/src/styles/globals.css
+++ b/apps/desktop/src/styles/globals.css
@@ -6737,6 +6737,288 @@ body {
   border-color: #d2d4d8;
 }
 
+/* ── Team workspace beta preview ───────────────────────────────────── */
+.try-workspace-switch {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 3px;
+  margin: 2px 2px 9px;
+  padding: 3px;
+  border: 1px solid var(--border);
+  border-radius: 11px;
+  background: color-mix(in oklch, var(--bg) 52%, var(--bg-alt));
+}
+.try-workspace-switch button {
+  min-width: 0;
+  height: 30px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--fg-subtle);
+  font-size: 11.5px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.16s ease, color 0.16s ease, box-shadow 0.16s ease;
+}
+.try-workspace-switch button:hover { color: var(--fg); }
+.try-workspace-switch button.is-active {
+  color: var(--fg);
+  background: var(--bg);
+  box-shadow: 0 1px 3px rgba(15, 18, 22, 0.08);
+}
+.try-workspace-switch button span,
+.try-nav-beta {
+  padding: 1px 5px;
+  border-radius: 999px;
+  background: var(--gold-soft);
+  color: var(--gold-dim);
+  font-family: var(--font-mono);
+  font-size: 8px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.try-team-sidebar-content { padding-top: 2px; }
+.try-team-sidebar-label {
+  margin: 16px 10px 5px;
+  color: var(--fg-subtle);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+}
+.try-nav-beta { margin-left: auto; }
+.try-nav-disabled {
+  cursor: default;
+  opacity: 0.68;
+}
+.try-nav-disabled:hover {
+  color: var(--fg-muted);
+  background: transparent;
+}
+.try-nav-soon {
+  margin-left: auto;
+  color: var(--fg-subtle);
+  font-size: 9px;
+  font-weight: 500;
+}
+
+.try-team-panel {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 54px 34px 64px;
+  animation: try-panel-enter 0.2s cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+.try-team-inner {
+  width: min(920px, 100%);
+  margin: 0 auto;
+}
+.try-team-hero {
+  max-width: 710px;
+  margin-bottom: 28px;
+}
+.try-team-eyebrow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 15px;
+  color: var(--fg-muted);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.025em;
+}
+.try-team-eyebrow > svg { color: var(--gold-dim); }
+.try-team-beta {
+  padding: 3px 7px;
+  border-radius: 999px;
+  background: var(--gold-soft);
+  color: var(--gold-dim);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+.try-team-hero h1 {
+  margin: 0;
+  color: var(--fg);
+  font-family: var(--font-serif);
+  font-size: clamp(38px, 5vw, 58px);
+  font-weight: 400;
+  line-height: 1.02;
+  letter-spacing: -0.035em;
+}
+.try-team-hero > p {
+  max-width: 660px;
+  margin: 17px 0 0;
+  color: var(--fg-muted);
+  font-size: 15px;
+  line-height: 1.65;
+}
+.try-team-trust {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin-top: 18px;
+  color: var(--fg-subtle);
+  font-size: 11px;
+}
+.try-team-trust svg { color: var(--success); }
+.try-team-trust-dot {
+  width: 3px;
+  height: 3px;
+  margin: 0 3px;
+  border-radius: 50%;
+  background: var(--border-strong);
+}
+.try-team-agent-preview {
+  padding: 20px;
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  background: color-mix(in oklch, var(--bg) 92%, var(--gold-soft));
+  box-shadow: 0 12px 35px -30px rgba(15, 18, 22, 0.55);
+}
+.try-team-agent-head {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 14px;
+}
+.try-team-agent-head h2,
+.try-team-feature h3 {
+  margin: 0;
+  color: var(--fg);
+  font-size: 14px;
+  font-weight: 600;
+}
+.try-team-agent-head p,
+.try-team-feature p {
+  margin: 4px 0 0;
+  color: var(--fg-muted);
+  font-size: 12.5px;
+  line-height: 1.5;
+}
+.try-team-avatar-stack { display: flex; padding-left: 7px; }
+.try-team-avatar-stack span {
+  width: 31px;
+  height: 31px;
+  display: grid;
+  place-items: center;
+  margin-left: -7px;
+  border: 2px solid var(--bg);
+  border-radius: 50%;
+  background: var(--bg-alt);
+  color: var(--fg-muted);
+  font-family: var(--font-serif);
+  font-size: 14px;
+}
+.try-team-avatar-stack span:first-child {
+  background: var(--accent);
+  color: #fff;
+}
+.try-team-soon {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 8px;
+  border-radius: 999px;
+  background: var(--bg-alt);
+  color: var(--fg-subtle);
+  font-size: 10px;
+  white-space: nowrap;
+}
+.try-team-composer {
+  height: 48px;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin-top: 18px;
+  padding: 0 8px 0 14px;
+  border: 1px solid var(--border);
+  border-radius: 15px;
+  background: var(--bg-alt);
+  color: var(--fg-subtle);
+  font-size: 13px;
+}
+.try-team-composer span { flex: 1; }
+.try-team-composer button {
+  width: 33px;
+  height: 33px;
+  display: grid;
+  place-items: center;
+  border: 0;
+  border-radius: 50%;
+  background: var(--border);
+  color: var(--fg-subtle);
+}
+.try-team-feature-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 12px;
+}
+.try-team-feature {
+  min-height: 116px;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 12px;
+  padding: 17px;
+  border: 1px solid var(--border);
+  border-radius: 15px;
+  background: var(--bg);
+}
+.try-team-feature-icon {
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  border-radius: 10px;
+  background: var(--bg-alt);
+  color: var(--gold-dim);
+}
+.try-team-feature-icon svg { width: 17px; height: 17px; }
+.try-team-feature > span {
+  grid-column: 2;
+  align-self: end;
+  width: fit-content;
+  color: var(--fg-subtle);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.try-team-personal {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  margin-top: 20px;
+  padding: 9px 13px;
+  border: 1px solid var(--border-strong);
+  border-radius: 10px;
+  background: var(--bg);
+  color: var(--fg-muted);
+  font-size: 12px;
+  cursor: pointer;
+  transition: border-color 0.16s ease, color 0.16s ease, transform 0.16s ease;
+}
+.try-team-personal:hover { border-color: var(--gold-line); color: var(--fg); transform: translateY(-1px); }
+
+:root[data-theme="light"] .try-team-agent-preview,
+:root[data-theme="light"] .try-team-feature {
+  border-color: #e3e4e6;
+  box-shadow: 0 1px 2px rgba(15, 18, 22, 0.025);
+}
+@media (max-width: 760px) {
+  .try-team-panel { padding: 34px 20px 48px; }
+  .try-team-feature-grid { grid-template-columns: 1fr; }
+  .try-team-agent-head { grid-template-columns: auto minmax(0, 1fr); }
+  .try-team-soon { grid-column: 2; width: fit-content; }
+}
+
 @media (prefers-reduced-motion: reduce) {
   html,
   body,
@@ -6755,6 +7037,7 @@ body {
   .try-tools-panel,
   .try-gallery,
   .try-wallet-panel,
+  .try-team-panel,
   .try-phone {
     animation: none !important;
     transition: none !important;


### PR DESCRIPTION
## Summary
- add a Personal / Team Beta workspace switch in Franklin Desktop
- introduce a Team home preview for shared conversations, files, knowledge, and workflows
- label all cloud-backed capabilities Coming soon and state that this beta uploads nothing
- preserve existing Personal conversations and navigation

## Scope
This PR is an interface-only preview. It does not enable team cloud storage, permissions, member invites, shared wallets, or remote agent execution.

## Verification
- full test suite: 653 passed
- Desktop typecheck passed
- Desktop lint passed
- production Desktop build passed
- packaged macOS app manually verified for Team entry and return to Personal