### PR TITLE
fix(desktop): harden startup and connection feedback

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -39,10 +39,19 @@ let agentPort = process.env.FRANKLIN_AGENT_PORT || (DEV_URL ? "3737" : "0");
 if (AGENT_TOKEN) process.env.FRANKLIN_SERVE_TOKEN = AGENT_TOKEN;
 
 let win = null;
+let startupWin = null;
 let backend = null;
 let canvas = null;
 let canvasWin = null;
 let quitting = false;
+let backendReady = false;
+const rendererReadyWaiters = new Map();
+let startupState = {
+  status: "loading",
+  message: "Preparing your secure workspace…",
+};
+const hasSingleInstanceLock = app.requestSingleInstanceLock();
+if (!hasSingleInstanceLock) app.exit(0);
 
 function backendBaseEnvironment() {
   const allowed = [
@@ -71,6 +80,10 @@ function isTrustedMainRendererUrl(raw) {
   return raw === pathToFileURL(path.join(__dirname, "..", "dist", "index.html")).toString();
 }
 
+function isTrustedStartupRendererUrl(raw) {
+  return raw === pathToFileURL(path.join(__dirname, "startup.html")).toString();
+}
+
 function guardWindowNavigation(browserWindow, trustedUrl) {
   browserWindow.webContents.on("will-navigate", (event, url) => {
     const allowed = trustedUrl.startsWith("file:") ? url === trustedUrl : sameOrigin(url, trustedUrl);
@@ -86,6 +99,77 @@ function assertTrustedIpcSender(event) {
   if (!win || win.isDestroyed() || event.sender !== win.webContents || !isTrustedMainRendererUrl(event.sender.getURL())) {
     throw new Error("Rejected IPC from an untrusted renderer");
   }
+}
+
+function assertTrustedStartupIpcSender(event) {
+  if (!startupWin || startupWin.isDestroyed() || event.sender !== startupWin.webContents || !isTrustedStartupRendererUrl(event.sender.getURL())) {
+    throw new Error("Rejected startup IPC from an untrusted renderer");
+  }
+}
+
+function updateStartupState(status, message) {
+  startupState = { status, message };
+  if (startupWin && !startupWin.isDestroyed() && !startupWin.webContents.isLoading()) {
+    startupWin.webContents.send("franklin:startup-state", startupState);
+  }
+}
+
+function createStartupWindow() {
+  if (startupWin && !startupWin.isDestroyed()) {
+    startupWin.show();
+    startupWin.focus();
+    return startupWin;
+  }
+
+  startupWin = new BrowserWindow({
+    width: 440,
+    height: 300,
+    resizable: false,
+    maximizable: false,
+    fullscreenable: false,
+    frame: false,
+    show: false,
+    center: true,
+    backgroundColor: "#f7f6f1",
+    webPreferences: {
+      preload: path.join(__dirname, "startup-preload.cjs"),
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+    },
+  });
+
+  const startupUrl = pathToFileURL(path.join(__dirname, "startup.html")).toString();
+  guardWindowNavigation(startupWin, startupUrl);
+  startupWin.once("ready-to-show", () => {
+    if (startupWin && !startupWin.isDestroyed()) startupWin.show();
+  });
+  startupWin.webContents.on("did-finish-load", () => {
+    if (startupWin && !startupWin.isDestroyed()) {
+      startupWin.webContents.send("franklin:startup-state", startupState);
+    }
+  });
+  startupWin.on("closed", () => { startupWin = null; });
+  void startupWin.loadFile(path.join(__dirname, "startup.html")).catch((error) => {
+    console.error("[franklin-desktop] failed to load startup window", error);
+  });
+  return startupWin;
+}
+
+function closeStartupWindow() {
+  if (!startupWin || startupWin.isDestroyed()) return;
+  startupWin.close();
+  startupWin = null;
+}
+
+if (hasSingleInstanceLock) {
+  app.on("second-instance", () => {
+    const activeWindow = win && !win.isDestroyed() ? win : startupWin;
+    if (!activeWindow || activeWindow.isDestroyed()) return;
+    if (activeWindow.isMinimized()) activeWindow.restore();
+    activeWindow.show();
+    activeWindow.focus();
+  });
 }
 
 // Auto-start Franklin Canvas (its own backend :3100 + Vite UI :5173) so the
@@ -233,20 +317,20 @@ async function openCanvasWindow() {
   }
 }
 
-async function loadRenderer() {
+async function loadRenderer(targetWindow) {
   if (DEV_URL) {
     // Vite may still be coming up — retry until it answers.
     for (let i = 0; i < 40; i++) {
       try {
-        await win.loadURL(DEV_URL);
+        await targetWindow.loadURL(DEV_URL);
         return;
       } catch {
         await new Promise((r) => setTimeout(r, 300));
       }
     }
-    await win.loadURL(DEV_URL); // final attempt; let the error surface
+    await targetWindow.loadURL(DEV_URL); // final attempt; let the error surface
   } else {
-    await win.loadFile(path.join(__dirname, "..", "dist", "index.html"));
+    await targetWindow.loadFile(path.join(__dirname, "..", "dist", "index.html"));
   }
 }
 
@@ -256,7 +340,8 @@ function createWindow() {
     height: 800,
     minWidth: 720,
     minHeight: 480,
-    backgroundColor: "#ffffff",
+    backgroundColor: "#f7f6f1",
+    show: false,
     titleBarStyle: process.platform === "darwin" ? "hiddenInset" : "default",
     webPreferences: {
       preload: path.join(__dirname, "preload.cjs"),
@@ -269,27 +354,114 @@ function createWindow() {
   const trustedRendererUrl = DEV_URL || pathToFileURL(path.join(__dirname, "..", "dist", "index.html")).toString();
   guardWindowNavigation(win, trustedRendererUrl);
 
-  loadRenderer();
+  win.webContents.on("did-fail-load", (_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
+    if (isMainFrame) {
+      console.error("[franklin-desktop] renderer load failed", { errorCode, errorDescription, validatedURL });
+    }
+  });
+  win.webContents.on("render-process-gone", (_event, details) => {
+    console.error("[franklin-desktop] renderer process exited", details);
+    if (quitting) return;
+    if (win && !win.isDestroyed()) win.destroy();
+    win = null;
+    createStartupWindow();
+    updateStartupState("error", "Franklin stopped unexpectedly. Please try again.");
+  });
   win.on("closed", () => {
     win = null;
   });
+  return win;
 }
 
-app.whenReady().then(async () => {
+function waitForRendererContent(targetWindow) {
+  return new Promise((resolve, reject) => {
+    const webContentsId = targetWindow.webContents.id;
+    let settled = false;
+    const finish = (callback) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      rendererReadyWaiters.delete(webContentsId);
+      callback();
+    };
+    const timeout = setTimeout(() => {
+      finish(() => reject(new Error("Franklin’s interface did not become ready in time.")));
+    }, 15_000);
+    rendererReadyWaiters.set(webContentsId, () => finish(resolve));
+    targetWindow.once("closed", () => {
+      finish(() => reject(new Error("Franklin window closed before its interface was ready.")));
+    });
+  });
+}
+
+async function openMainWindow() {
+  if (win && !win.isDestroyed()) {
+    win.show();
+    win.focus();
+    closeStartupWindow();
+    return;
+  }
+
+  const mainWindow = createWindow();
+  const rendererReady = waitForRendererContent(mainWindow);
+  await loadRenderer(mainWindow);
+  await rendererReady;
+  if (mainWindow.isDestroyed()) throw new Error("Franklin window closed before it was ready.");
+  mainWindow.show();
+  mainWindow.focus();
+  closeStartupWindow();
+}
+
+async function startApplication() {
+  createStartupWindow();
+  updateStartupState("loading", "Preparing your secure workspace…");
   agentPort = await startBackend();
+  backendReady = true;
   process.env.FRANKLIN_AGENT_PORT = agentPort;
-  startCanvas();
+  updateStartupState("loading", "Opening Franklin…");
+  void startCanvas();
+  await openMainWindow();
+}
+
+app.whenReady().then(() => {
+  if (!hasSingleInstanceLock) return;
   ipcMain.handle("franklin:open-canvas", (event) => {
     assertTrustedIpcSender(event);
     return openCanvasWindow();
   });
-  createWindow();
-  app.on("activate", () => {
-    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  ipcMain.on("franklin:renderer-ready", (event) => {
+    assertTrustedIpcSender(event);
+    rendererReadyWaiters.get(event.sender.id)?.();
   });
-}).catch((error) => {
-  console.error("[franklin-desktop] startup failed", error);
-  app.quit();
+  ipcMain.handle("franklin:startup-retry", (event) => {
+    assertTrustedStartupIpcSender(event);
+    app.relaunch();
+    app.exit(0);
+  });
+  void startApplication().catch((error) => {
+    console.error("[franklin-desktop] startup failed", error);
+    if (win && !win.isDestroyed()) win.destroy();
+    win = null;
+    createStartupWindow();
+    updateStartupState("error", "Franklin couldn’t start. Please try again.");
+  });
+  app.on("activate", () => {
+    if (!backendReady) {
+      createStartupWindow();
+      return;
+    }
+    if (win && !win.isDestroyed()) {
+      win.show();
+      win.focus();
+      return;
+    }
+    createStartupWindow();
+    updateStartupState("loading", "Opening Franklin…");
+    void openMainWindow().catch((error) => {
+      console.error("[franklin-desktop] failed to reopen window", error);
+      updateStartupState("error", "Franklin couldn’t open its window. Please try again.");
+    });
+  });
 });
 
 app.on("window-all-closed", () => {

--- a/apps/desktop/electron/preload.cjs
+++ b/apps/desktop/electron/preload.cjs
@@ -10,6 +10,15 @@ const token = process.env.FRANKLIN_SERVE_TOKEN || "";
 const agentUrl = new URL(`ws://127.0.0.1:${port}/agent`);
 if (token) agentUrl.searchParams.set("token", token);
 
+// `ready-to-show` can fire before React paints meaningful content. Wait for two
+// animation frames after DOMContentLoaded, then let the main process replace
+// the startup window. This keeps a blank Electron surface off screen.
+window.addEventListener("DOMContentLoaded", () => {
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => ipcRenderer.send("franklin:renderer-ready"));
+  });
+}, { once: true });
+
 contextBridge.exposeInMainWorld("__FRANKLIN__", {
   agentUrl: agentUrl.toString(),
   // Franklin Canvas (node-based media studio) opens in its own native window;

--- a/apps/desktop/electron/startup-preload.cjs
+++ b/apps/desktop/electron/startup-preload.cjs
@@ -1,0 +1,9 @@
+const { contextBridge, ipcRenderer } = require("electron");
+
+contextBridge.exposeInMainWorld("franklinStartup", {
+  onState: (callback) => {
+    if (typeof callback !== "function") return;
+    ipcRenderer.on("franklin:startup-state", (_event, state) => callback(state));
+  },
+  retry: () => ipcRenderer.invoke("franklin:startup-retry"),
+});

--- a/apps/desktop/electron/startup.css
+++ b/apps/desktop/electron/startup.css
@@ -1,0 +1,137 @@
+:root {
+  color-scheme: light;
+  font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #f7f6f1;
+  color: #24231f;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
+}
+
+body {
+  -webkit-app-region: drag;
+  background:
+    radial-gradient(circle at 50% 8%, rgba(182, 153, 67, 0.13), transparent 46%),
+    #f7f6f1;
+}
+
+.startup-shell {
+  display: flex;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  padding: 32px;
+  text-align: center;
+}
+
+.brand-mark {
+  width: 72px;
+  height: 72px;
+  padding: 5px;
+  overflow: hidden;
+  border: 1px solid rgba(103, 86, 34, 0.14);
+  border-radius: 23px;
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: 0 14px 34px rgba(57, 49, 24, 0.12);
+}
+
+.brand-mark img {
+  width: 100%;
+  height: 100%;
+  border-radius: 18px;
+  object-fit: cover;
+}
+
+h1 {
+  margin: 16px 0 7px;
+  color: #6d5a1f;
+  font-size: 27px;
+  font-weight: 650;
+  letter-spacing: -0.025em;
+}
+
+#status {
+  min-height: 20px;
+  margin: 0;
+  color: #6f6d66;
+  font-size: 13px;
+  line-height: 20px;
+}
+
+.progress {
+  display: flex;
+  gap: 6px;
+  height: 22px;
+  align-items: center;
+  margin-top: 8px;
+}
+
+.progress span {
+  width: 6px;
+  height: 6px;
+  animation: pulse 1.2s ease-in-out infinite;
+  border-radius: 50%;
+  background: #a48a3a;
+  opacity: 0.25;
+}
+
+.progress span:nth-child(2) {
+  animation-delay: 0.16s;
+}
+
+.progress span:nth-child(3) {
+  animation-delay: 0.32s;
+}
+
+button {
+  -webkit-app-region: no-drag;
+  margin-top: 16px;
+  padding: 9px 18px;
+  border: 1px solid #786527;
+  border-radius: 10px;
+  background: #786527;
+  color: #fff;
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+button:hover {
+  background: #66551f;
+}
+
+.hint {
+  margin: 13px 0 0;
+  color: #8b8981;
+  font-size: 11px;
+}
+
+@keyframes pulse {
+  0%, 80%, 100% {
+    transform: scale(0.75);
+    opacity: 0.25;
+  }
+
+  40% {
+    transform: scale(1);
+    opacity: 0.9;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .progress span {
+    animation: none;
+    opacity: 0.65;
+  }
+}

--- a/apps/desktop/electron/startup.html
+++ b/apps/desktop/electron/startup.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self'; style-src 'self'; script-src 'self'" />
+    <title>Starting Franklin</title>
+    <link rel="stylesheet" href="./startup.css" />
+  </head>
+  <body>
+    <main class="startup-shell" aria-live="polite">
+      <div class="brand-mark" aria-hidden="true">
+        <img src="../dist/franklin-avatar.png" alt="" />
+      </div>
+      <h1>Franklin</h1>
+      <p id="status">Preparing your secure workspace…</p>
+      <div id="progress" class="progress" aria-label="Starting">
+        <span></span><span></span><span></span>
+      </div>
+      <button id="retry" type="button" hidden>Try again</button>
+      <p id="hint" class="hint" hidden>Your conversations and wallet remain on this Mac.</p>
+    </main>
+    <script src="./startup.js"></script>
+  </body>
+</html>

--- a/apps/desktop/electron/startup.js
+++ b/apps/desktop/electron/startup.js
@@ -1,0 +1,21 @@
+const status = document.querySelector("#status");
+const progress = document.querySelector("#progress");
+const retry = document.querySelector("#retry");
+const hint = document.querySelector("#hint");
+
+window.franklinStartup?.onState((state) => {
+  const isError = state?.status === "error";
+  status.textContent = typeof state?.message === "string" ? state.message : "Starting Franklin…";
+  progress.hidden = isError;
+  retry.hidden = !isError;
+  hint.hidden = !isError;
+});
+
+retry.addEventListener("click", () => {
+  retry.disabled = true;
+  retry.textContent = "Restarting…";
+  status.textContent = "Restarting Franklin…";
+  progress.hidden = false;
+  hint.hidden = true;
+  void window.franklinStartup?.retry();
+});

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockrun/franklin-desktop",
-  "version": "0.1.2",
+  "version": "0.1.3-beta.1",
   "description": "Franklin Desktop — native desktop app for the Franklin agent (Electron). Same agent, wallet and tools as the CLI, in a polished window.",
   "license": "Apache-2.0",
   "type": "module",

--- a/apps/desktop/src/components/FranklinChat.tsx
+++ b/apps/desktop/src/components/FranklinChat.tsx
@@ -62,7 +62,7 @@ function EmphTitle({ text }: { text: string }) {
 export function FranklinChat() {
   const { t } = useTryLang();
   const auth = useAuth();
-  const { wallet } = useWallet();
+  const { wallet, connectionState: walletConnectionState, isLoading: walletLoading, error: walletError } = useWallet();
   const history = useChatHistory(auth.address);
   const usage = useSpend();
   const chat = useFranklinChat(history.messages, history.setMessages, history.ensureConvId);
@@ -236,6 +236,9 @@ export function FranklinChat() {
           closeSidebarOnMobile();
         }}
         wallet={wallet}
+        walletConnectionState={walletConnectionState}
+        walletLoading={walletLoading}
+        walletError={walletError}
       />
 
       {sidebarOpen && <div className="try-sidebar-scrim" onClick={() => setSidebarOpen(false)} />}

--- a/apps/desktop/src/components/HistorySidebar.tsx
+++ b/apps/desktop/src/components/HistorySidebar.tsx
@@ -5,6 +5,7 @@ import {
 } from "lucide-react";
 import type { Conversation } from "../hooks/use-chat-history";
 import type { WalletInfo } from "../lib/wire";
+import type { AgentConnectionState } from "../lib/ws";
 import { useTryLang } from "../lib/i18n";
 import { MoreMenu } from "./MoreMenu";
 import { WalletPill } from "./WalletPill";
@@ -29,9 +30,12 @@ interface Props {
   onWorkspaceMode: (mode: WorkspaceMode) => void;
   /** Local CLI wallet (read-only) — replaces run's browser connect-wallet UI. */
   wallet: WalletInfo | null;
+  walletConnectionState: AgentConnectionState;
+  walletLoading: boolean;
+  walletError: string | null;
 }
 
-export function HistorySidebar({ conversations, activeId, onNew, onSelect, onDelete, view, onView, open, workspaceMode, onWorkspaceMode, wallet }: Props) {
+export function HistorySidebar({ conversations, activeId, onNew, onSelect, onDelete, view, onView, open, workspaceMode, onWorkspaceMode, wallet, walletConnectionState, walletLoading, walletError }: Props) {
   const { t, lang } = useTryLang();
   const [searchOpen, setSearchOpen] = useState(false);
   const [moreOpen, setMoreOpen] = useState(false);
@@ -180,7 +184,12 @@ export function HistorySidebar({ conversations, activeId, onNew, onSelect, onDel
         <div className="try-footer-icons">
           <MoreMenu />
           <div className="try-footer-wallet">
-            <WalletPill wallet={wallet} />
+            <WalletPill
+              wallet={wallet}
+              connectionState={walletConnectionState}
+              isLoading={walletLoading}
+              error={walletError}
+            />
           </div>
         </div>
       </div>

--- a/apps/desktop/src/components/WalletPill.tsx
+++ b/apps/desktop/src/components/WalletPill.tsx
@@ -7,25 +7,38 @@
 import { useState } from "react";
 import { Copy, Check } from "lucide-react";
 import type { WalletInfo } from "../lib/wire";
+import type { AgentConnectionState } from "../lib/ws";
 import { copyText } from "../lib/clipboard";
 
 interface Props {
   wallet: WalletInfo | null;
+  connectionState: AgentConnectionState;
+  isLoading: boolean;
+  error: string | null;
 }
 
 function fmtBal(n: number): string {
   return `$${n < 0.01 ? n.toFixed(4) : n.toFixed(2)}`;
 }
 
-export function WalletPill({ wallet }: Props) {
+export function WalletPill({ wallet, connectionState, isLoading, error }: Props) {
   const [copied, setCopied] = useState(false);
 
-  if (!wallet) {
+  if (connectionState !== "open" || !wallet) {
+    const status = connectionState === "connecting"
+      ? "Connecting…"
+      : connectionState === "closed"
+        ? "Reconnecting…"
+        : isLoading
+          ? "Loading wallet…"
+          : error
+            ? "Wallet unavailable"
+            : "Wallet unavailable";
     return (
-      <div className="try-wallet" style={{ opacity: 0.6 }}>
+      <div className="try-wallet" style={{ opacity: 0.72 }}>
         <div className="try-wallet-info">
           <div className="try-wallet-row1">
-            <span className="try-wallet-net">CLI offline</span>
+            <span className="try-wallet-net">{status}</span>
           </div>
           <span className="try-wallet-addr">—</span>
         </div>

--- a/apps/desktop/src/hooks/use-wallet.ts
+++ b/apps/desktop/src/hooks/use-wallet.ts
@@ -9,12 +9,13 @@
 // different gateway balances). One source of truth fixes that mismatch.
 
 import { useEffect, useState } from "react";
-import { agent } from "../lib/ws";
+import { agent, type AgentConnectionState } from "../lib/ws";
 import type { ServerMsg, WalletInfo } from "../lib/wire";
 
 let current: WalletInfo | null = null;
 let loading = true;
 let lastError: string | null = null;
+let connectionState: AgentConnectionState = agent.state;
 let started = false;
 const subs = new Set<() => void>();
 
@@ -40,7 +41,11 @@ async function refresh() {
 function ensureStarted() {
   if (started) return;
   started = true;
-  agent.onState((state) => { if (state === "open") void refresh(); });
+  agent.onState((state) => {
+    connectionState = state;
+    emit();
+    if (state === "open") void refresh();
+  });
   // CLI broadcasts wallet.event after every turn (settlement may have changed
   // the balance); merge it into the shared state so all consumers update.
   agent.subscribe((msg: ServerMsg) => {
@@ -57,7 +62,12 @@ function ensureStarted() {
   setInterval(() => { void refresh(); }, 30_000);
 }
 
-export function useWallet(): { wallet: WalletInfo | null; isLoading: boolean; error: string | null } {
+export function useWallet(): {
+  wallet: WalletInfo | null;
+  isLoading: boolean;
+  error: string | null;
+  connectionState: AgentConnectionState;
+} {
   ensureStarted();
   const [, force] = useState(0);
   useEffect(() => {
@@ -65,5 +75,5 @@ export function useWallet(): { wallet: WalletInfo | null; isLoading: boolean; er
     subs.add(fn);
     return () => { subs.delete(fn); };
   }, []);
-  return { wallet: current, isLoading: loading, error: lastError };
+  return { wallet: current, isLoading: loading, error: lastError, connectionState };
 }

--- a/apps/desktop/src/lib/ws.ts
+++ b/apps/desktop/src/lib/ws.ts
@@ -16,6 +16,7 @@
 import type { ClientMsg, ClientMsgKind, ServerMsg, ServerMsgKind } from "./wire";
 
 type Listener = (msg: ServerMsg) => void;
+export type AgentConnectionState = "connecting" | "open" | "closed";
 
 interface Pending {
   resolve: (value: ServerMsg) => void;
@@ -40,7 +41,7 @@ class AgentSocket {
   private url: string;
 
   /** Last connection state, exposed via subscribe(). React hooks render off it. */
-  state: "connecting" | "open" | "closed" = "closed";
+  state: AgentConnectionState = "closed";
 
   constructor() {
     // Three load contexts:

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
     },
     "apps/desktop": {
       "name": "@blockrun/franklin-desktop",
-      "version": "0.1.2",
+      "version": "0.1.3-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@blockrun/franklin": "*",


### PR DESCRIPTION
## Summary
- replace the initial white window with a branded startup screen
- wait for the renderer first paint before revealing the main window
- show a retryable failure screen when the agent or renderer cannot start
- add single-instance focus behavior and trusted startup IPC checks
- distinguish connecting, reconnecting, loading-wallet, and unavailable states
- version the desktop beta as 0.1.3-beta.1

## Validation
- desktop typecheck, lint, production build, and macOS packaging passed
- three Finder cold-start cycles passed with wallet recovery
- repeat-open kept one window and one backend
- exact 0.1.3-beta.1 clean-package launch passed
- no new macOS crash reports were generated

## Release artifact
- Franklin-0.1.3-beta.1-arm64.dmg
- SHA-256: 4595c3583292c8802e024ace8522d15034985bdc9f9cfbfe5fab41bed37ad605

This remains an unsigned, non-notarized beta.