### PR TITLE
release: 3.42.0 — router-core d7bc10c, and the dead-rung kill-switch is wired

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Franklin Agent
 
-Open-source AI agent with a wallet. <!-- br:models.chatVisible -->71<!-- /br:models.chatVisible --> models. Pay per use with USDC via x402.
+Open-source AI agent with a wallet. <!-- br:models.chatVisible -->72<!-- /br:models.chatVisible --> models. Pay per use with USDC via x402.
 
 ## Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,57 @@
 # Changelog
 
+## Franklin Agent 3.42.0 — router-core d7bc10c, and the dead-rung kill-switch is wired
+
+**The shared Router can now be told a model is gone — and Franklin tells it.**
+`@blockrun/router-core` moves from `6a790eb` to `d7bc10c` (eleven commits):
+the `free/gpt-oss-120b` / `-20b` rungs that had been 400-ing for two weeks are
+retired in the core, `free/deepseek-v4-flash` (NVIDIA EOL, 410) leaves the eco
+chain, and `options.unavailableModels` arrives — ids the host has observed
+dead are hard-removed from every tier chain before selection, never restored
+by an eligibility fail-open, effective on the next request instead of after a
+core release and two consumer repins. Franklin now feeds it from two sources.
+The first is a **quarantine**: `d7bc10c` makes `nvidia/step-3.7-flash` the
+free backstop rung of every Auto chain, and a live probe today still came back
+served by `nvidia/nemotron-3-super-120b` with the reasoning trace duplicated
+into `content` — the same "never promise a model the user doesn't get" rule
+the picker already applies, so Franklin's Auto chains end one rung earlier.
+The second is **runtime observation**: the error classifier flags a rejected
+model id (`400 Unknown model`, 404, or a 410 provider EOL) as
+`modelUnavailable`, distinct from the request-shape errors it shares a
+category with, and when Auto routing picked that id the loop marks it dead
+(`markModelUnavailable`) and re-routes the same turn — bounded to three
+re-routes per turn so a chain that is dead end-to-end surfaces the error
+instead of cycling. A concrete user-pinned model is left alone; the user chose
+it, and the suggestion already says `/model`.
+
+**Absence from `/v1/models` is not death, and this release nearly got that
+wrong.** The catalog no longer lists Opus 4.6, the Kimi K2.x line, the xAI
+3.x / 4-0709 / 4-fast family or `gpt-5-nano`, and the core config still names
+every one of them. Before declaring them dead they were all called through the
+binary: every one answered and every one was charged. So nothing is retired on
+catalog grounds — the static dead list ships empty with the probe recorded
+beside it, the explicit picker pins keep resolving to the real ids, their
+pricing stays at list (regrouped under one "hidden from `/v1/models`, still
+served" heading, each probed id marked), and the vision allowlist keeps them.
+One observed number worth knowing if you pin them: a 12-token-in /
+13-token-out probe cost **$0.097 on `xai/grok-3` and `xai/grok-4-0709`** —
+`grok` (4.5) is the cheaper flagship.
+
+**GLM-5.3 Flash lands in every table.** The one model the catalog gained since
+3.40.0: $0.15/$0.5, 1M context, and the only GLM SKU tagged multimodal. It is
+priced, sized, on the vision allowlist, pinnable as `glm-flash` /
+`glm-5.3-flash`, and takes Gemini 2.5 Flash's row in the Budget picker (half
+the price, same 1M and vision, plus reasoning; `gemini-2.5-flash` still
+resolves — hide the row, keep the shortcut).
+
+Also: the gateway API brief the agent carries now lists `zai/glm-5.3-flash`
+among its verified-live examples (2026-08-29); the plugin-SDK tier table and
+the live e2e checklist no longer point at `nvidia/qwen3-coder-480b`, retired
+months ago; brand numbers re-synced from the canonical artifact (72 visible
+chat models). Seven new local tests pin the kill-switch (static, per-call and
+observed), the classifier flag, the GLM-5.3 Flash tables, and the
+hidden-but-served invariant.
+
 ## Franklin Agent 3.41.0 — card funding on Solana, and Solana becomes the default
 
 **Onramp was Base-only in three places; now it follows the wallet.** The

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Capability pillars:
 
 Built on three layers:
 1. **x402 micropayment protocol** — HTTP 402 native payments
-2. **BlockRun Gateway** — aggregates <!-- br:models.chatVisible -->71<!-- /br:models.chatVisible --> LLMs + paid APIs (Exa, DALL-E, future Runway/Suno/CoinGecko)
+2. **BlockRun Gateway** — aggregates <!-- br:models.chatVisible -->72<!-- /br:models.chatVisible --> LLMs + paid APIs (Exa, DALL-E, future Runway/Suno/CoinGecko)
 3. **Franklin Agent** — this repo, the reference client
 
 ## Commands

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -19,7 +19,7 @@ The first, unpaid HTTP request whose 402 response carries the payment terms; Fra
 _Avoid_: Pre-flight, handshake.
 
 **BlockRun Gateway**:
-The single upstream service Franklin calls for both LLM completions and paid tools (Exa, ImageGen, VideoGen, MusicGen, market data); aggregates <!-- br:models.chatVisible -->71<!-- /br:models.chatVisible --> models and accepts x402.
+The single upstream service Franklin calls for both LLM completions and paid tools (Exa, ImageGen, VideoGen, MusicGen, market data); aggregates <!-- br:models.chatVisible -->72<!-- /br:models.chatVisible --> models and accepts x402.
 _Avoid_: API, provider, backend, BlockRun (without "Gateway") when referring to the service.
 
 **Per-turn spend cap**:

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Every tool call is itemized. Every token is priced. When the wallet hits zero, F
 
 ## Smart Router
 
-**<!-- br:models.chatVisible -->71<!-- /br:models.chatVisible --> models. One decision. Zero guesswork.**
+**<!-- br:models.chatVisible -->72<!-- /br:models.chatVisible --> models. One decision. Zero guesswork.**
 
 You don't pick models. Franklin picks for you.
 
@@ -338,7 +338,7 @@ No email. No phone. No KYC. Your Base or Solana address is your account — port
 | Writes code                            | ✅               | ✅               | ⚠️                | ✅                              |
 | **Spends money for you**               | ❌               | ❌               | ❌               | ✅ **USDC wallet, x402**        |
 | **Buys data + APIs + images + search** | ❌               | ❌               | ❌               | ✅ **55+ APIs, one wallet**     |
-| Picks best model per task              | ❌ single-vendor | ❌ plan-tied    | ❌               | ✅ **Smart Router, <!-- br:models.chatVisible -->71<!-- /br:models.chatVisible --> models** |
+| Picks best model per task              | ❌ single-vendor | ❌ plan-tied    | ❌               | ✅ **Smart Router, <!-- br:models.chatVisible -->72<!-- /br:models.chatVisible --> models** |
 | Pricing model                          | Subscription     | Subscription     | Subscription     | **YOPO** — per outcome, USDC    |
 | Monthly fee                            | $20–$200         | $20–$40          | $20+             | **$0**                          |
 | Rate-limited                           | Yes              | Yes              | Yes              | No — limited only by wallet     |
@@ -366,14 +366,14 @@ Ask "what's BTC looking like?" — Franklin fetches live price data, computes RS
 **🎨 AI image generation**
 Ask "generate a logo" — Franklin calls DALL-E / GPT Image, saves the result locally, paid from your wallet.
 
-**🧠 <!-- br:models.chatVisible -->71<!-- /br:models.chatVisible --> models via one wallet**
+**🧠 <!-- br:models.chatVisible -->72<!-- /br:models.chatVisible --> models via one wallet**
 Anthropic, OpenAI, Google, xAI, DeepSeek, GLM, Kimi, Minimax, NVIDIA free tier. One wallet, one interface, automatic fallback.
 
 **💳 x402 micropayments (YOPO)**
 HTTP 402 native. Every paid action is a signed USDC micropayment via EIP-712 — non-custodial, your keys never leave your machine. YOPO: you pay only for outcomes.
 
 **🧠 Learned model router**
-Trained on 2M+ real requests. Classifies your task and picks the best model from <!-- br:models.chatVisible -->71<!-- /br:models.chatVisible --> LLMs. Four profiles (auto/eco/premium/free). Adapts to your usage over time.
+Trained on 2M+ real requests. Classifies your task and picks the best model from <!-- br:models.chatVisible -->72<!-- /br:models.chatVisible --> LLMs. Four profiles (auto/eco/premium/free). Adapts to your usage over time.
 
 </td>
 <td width="50%" valign="top">

--- a/brand-numbers.json
+++ b/brand-numbers.json
@@ -2,8 +2,8 @@
   "$schema": "https://blockrun.ai/brand/numbers.schema.json",
   "version": 1,
   "models": {
-    "chatVisible": 71,
-    "totalVisible": 95,
+    "chatVisible": 72,
+    "totalVisible": 96,
     "free": 5,
     "freeWithheld": 20,
     "image": 9,

--- a/docs/adr/0002-blockrun-gateway-as-aggregator.md
+++ b/docs/adr/0002-blockrun-gateway-as-aggregator.md
@@ -2,7 +2,7 @@
 
 **Status:** accepted
 
-Franklin makes every LLM and paid-tool call through a single counterparty — the BlockRun Gateway — instead of integrating directly with each model provider, image/video/audio service, search API, and market-data feed. The gateway aggregates <!-- br:models.chatVisible -->71<!-- /br:models.chatVisible --> models and a small set of paid APIs and accepts x402 uniformly.
+Franklin makes every LLM and paid-tool call through a single counterparty — the BlockRun Gateway — instead of integrating directly with each model provider, image/video/audio service, search API, and market-data feed. The gateway aggregates <!-- br:models.chatVisible -->72<!-- /br:models.chatVisible --> models and a small set of paid APIs and accepts x402 uniformly.
 
 ## Considered options
 

--- a/docs/live-e2e-checklist.md
+++ b/docs/live-e2e-checklist.md
@@ -87,7 +87,7 @@ FREE_MODEL_MATRIX_PROBES=echo npm run test:free-models
 To isolate one or two models:
 
 ```bash
-FREE_MODEL_MATRIX=nvidia/qwen3-coder-480b,maverick npm run test:free-models
+FREE_MODEL_MATRIX=nvidia/nemotron-nano-9b-v2,omni npm run test:free-models
 ```
 
 Expected result:

--- a/docs/plugin-sdk.md
+++ b/docs/plugin-sdk.md
@@ -148,8 +148,8 @@ Workflows pick a tier per step; the runner resolves to actual models.
 
 | Tier | Default | When to use |
 |------|---------|-------------|
-| `free` | nvidia/qwen3-coder-480b | Warmup, throwaway calls, $0 cost |
-| `cheap` | nvidia/qwen3-coder-480b | Filtering, classification, $0 cost by default |
+| `free` | nvidia/nemotron-nano-9b-v2 | Warmup, throwaway calls, $0 cost |
+| `cheap` | nvidia/nemotron-nano-9b-v2 | Filtering, classification, $0 cost by default |
 | `premium` | anthropic/claude-sonnet-4.6 | High-stakes content, ~$0.02/call |
 | `none` | (no model) | Steps that don't call LLMs |
 | `dynamic` | (runtime decision) | Step decides based on context |

--- a/docs/why-ai-agents-need-a-wallet.md
+++ b/docs/why-ai-agents-need-a-wallet.md
@@ -154,7 +154,7 @@ cheap models because cheapness is now something the agent can
 agents both learn in real time.
 
 **3. Single-vendor failure becomes a one-command swap.** A router
-with <!-- br:models.chatVisible -->71<!-- /br:models.chatVisible --> models across every major provider can route around any
+with <!-- br:models.chatVisible -->72<!-- /br:models.chatVisible --> models across every major provider can route around any
 single vendor's bad release. The wallet doesn't know or care which
 model answered — it only pays for the answer that arrived.
 
@@ -175,7 +175,7 @@ filled it.
 
 Franklin is the reference implementation of the Economic Agent. It's
 an AI agent CLI that holds USDC on Base or Solana, routes requests
-across <!-- br:models.chatVisible -->71<!-- /br:models.chatVisible --> models, and settles every paid action in real time via
+across <!-- br:models.chatVisible -->72<!-- /br:models.chatVisible --> models, and settles every paid action in real time via
 the [x402](https://x402.org) HTTP-402 micropayment protocol. It is
 Apache-2.0, written in TypeScript, and ships as one npm package.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@blockrun/franklin",
-  "version": "3.41.0",
+  "version": "3.42.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockrun/franklin",
-      "version": "3.41.0",
+      "version": "3.42.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@blockrun/llm": "^3.13.1",
-        "@blockrun/router-core": "https://codeload.github.com/BlockRunAI/router-core/tar.gz/6a790ebec60161825bbc8c4093fd221006b4e5fb",
+        "@blockrun/router-core": "https://codeload.github.com/BlockRunAI/router-core/tar.gz/d7bc10ce184b3daa40bcc115b523fd629d847a52",
         "@colbymchenry/codegraph": "^1.5.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@polymarket/builder-relayer-client": "^0.0.10",
@@ -139,8 +139,8 @@
     },
     "node_modules/@blockrun/router-core": {
       "version": "0.1.0",
-      "resolved": "https://codeload.github.com/BlockRunAI/router-core/tar.gz/6a790ebec60161825bbc8c4093fd221006b4e5fb",
-      "integrity": "sha512-DZly4fJb8IKav+XWBJqUkHvD+EME78EgKaAiajd4zqfKNK4wB18/mjEP3Ydf79JEivf3VDjb3TmWrcOZivrexw==",
+      "resolved": "https://codeload.github.com/BlockRunAI/router-core/tar.gz/d7bc10ce184b3daa40bcc115b523fd629d847a52",
+      "integrity": "sha512-HwZUMTZhtsvsXkjClUdyHX9gtrS9Tk1G2RV/gafjGDKOfJ3bObX0SwO+mT15zkw1TE//bUyEwxF/L0s+ltXU9g==",
       "license": "MIT",
       "engines": {
         "node": ">=20.19.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockrun/franklin",
-  "version": "3.41.0",
+  "version": "3.42.0",
   "description": "Franklin Agent — The AI agent with a wallet. Spends USDC autonomously to get real work done. Pay per action, no subscriptions.",
   "type": "module",
   "exports": {
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "@blockrun/llm": "^3.13.1",
-    "@blockrun/router-core": "https://codeload.github.com/BlockRunAI/router-core/tar.gz/6a790ebec60161825bbc8c4093fd221006b4e5fb",
+    "@blockrun/router-core": "https://codeload.github.com/BlockRunAI/router-core/tar.gz/d7bc10ce184b3daa40bcc115b523fd629d847a52",
     "@colbymchenry/codegraph": "^1.5.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@polymarket/builder-relayer-client": "^0.0.10",

--- a/src/agent/context.ts
+++ b/src/agent/context.ts
@@ -254,7 +254,7 @@ You run on the BlockRun AI Gateway. When the user asks you to "test the BlockRun
 - \`GET /.well-known/x402\` — x402 resource list with prices
 
 **LLM (POST, x402-paid)**
-- \`POST /v1/chat/completions\` — OpenAI-compatible. Body: \`{ model, messages, stream?, tools?, max_tokens?, temperature? }\`. \`model\` MUST come from \`GET /v1/models\` (real frontier examples on the gateway, verified live 2026-08-19: \`anthropic/claude-sonnet-5\`, \`anthropic/claude-opus-5\`, \`openai/gpt-5.6-sol\`, \`deepseek/deepseek-v4-pro\`, \`zai/glm-5.3\`, \`xai/grok-4.5\`, \`qwen/qwen3.7-flash\`, \`nvidia/nemotron-nano-9b-v2\` (free)). Do NOT invent versions like \`openai/gpt-5.1\` or \`xai/grok-5\` — those don't exist; the gateway 400s with the valid list in the error body, so when in doubt fetch \`GET /v1/models\` first.
+- \`POST /v1/chat/completions\` — OpenAI-compatible. Body: \`{ model, messages, stream?, tools?, max_tokens?, temperature? }\`. \`model\` MUST come from \`GET /v1/models\` (real frontier examples on the gateway, verified live 2026-08-29: \`anthropic/claude-sonnet-5\`, \`anthropic/claude-opus-5\`, \`openai/gpt-5.6-sol\`, \`deepseek/deepseek-v4-pro\`, \`zai/glm-5.3\`, \`zai/glm-5.3-flash\`, \`xai/grok-4.5\`, \`qwen/qwen3.7-flash\`, \`nvidia/nemotron-nano-9b-v2\` (free)). Do NOT invent versions like \`openai/gpt-5.1\` or \`xai/grok-5\` — those don't exist; the gateway 400s with the valid list in the error body, so when in doubt fetch \`GET /v1/models\` first.
 - \`POST /v1/messages\` — Anthropic-compatible. Body: \`{ model, messages, max_tokens, system?, tools? }\`.
 
 **Media (POST, x402-paid; GET to poll async jobs)**

--- a/src/agent/error-classifier.ts
+++ b/src/agent/error-classifier.ts
@@ -37,6 +37,13 @@ export interface AgentErrorInfo {
    * malicious or buggy server can't pin the agent indefinitely.
    */
   retryAfterMs?: number;
+  /**
+   * The gateway rejected the model id itself (400 "Unknown model", 404, 410
+   * provider EOL) — not the request shape. Retrying the same id can never
+   * succeed; when the id came from Auto routing the loop feeds it to the
+   * router's dead-rung kill-switch (markModelUnavailable) and re-routes.
+   */
+  modelUnavailable?: boolean;
 }
 
 function includesAny(text: string, patterns: string[]): boolean {
@@ -247,15 +254,24 @@ export function classifyAgentError(message: string): AgentErrorInfo {
   // "Unknown model: moonshot/kimi-k2". Without this branch the error falls
   // through to the catch-all 'unknown' category and shows the user a bare
   // "Type: Unknown" with no actionable next step.
+  // A retired id looks the same to the loop: NVIDIA EOLs surface as HTTP
+  // 410 through the gateway (qwen3-next 2026-07-27, deepseek-v4-flash
+  // 2026-08-12), and a model the gateway dropped from its catalog 400s as
+  // unknown. Either way the id is dead for the rest of the session.
   if (includesAny(err, [
     'unknown model',
     'model not found',
     'model does not exist',
     'no such model',
-  ])) {
+    'model has been retired',
+    'model is retired',
+    'model is no longer available',
+    'model no longer available',
+  ]) || (/\b410\b/.test(err) && err.includes('model'))) {
     return {
       category: 'schema', label: 'Schema', isTransient: false, maxRetries: 0,
-      suggestion: 'The gateway rejected the model id (unknown / typo). Use /model to pick a valid one, or upgrade Franklin if a fallback chain references a stale id.',
+      modelUnavailable: true,
+      suggestion: 'The gateway rejected the model id (unknown / retired). Use /model to pick a valid one, or upgrade Franklin if a fallback chain references a stale id.',
     };
   }
 

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -45,7 +45,7 @@ import { writeLiveAgent } from '../session/live-registry.js';
 import { estimateCost, OPUS_PRICING } from '../pricing.js';
 import { maybeMidSessionExtract } from '../learnings/extractor.js';
 import { extractMentions, buildEntityContext, loadEntities } from '../brain/store.js';
-import { routeRequest, parseRoutingProfile, getFallbackChain, pickFreeFallback, isVisionModel, messageNeedsVision, pickVisionSibling } from '../router/index.js';
+import { routeRequest, parseRoutingProfile, getFallbackChain, pickFreeFallback, isVisionModel, messageNeedsVision, pickVisionSibling, markModelUnavailable } from '../router/index.js';
 import type { Tier, RoutingProfile, RoutingResult } from '../router/index.js';
 import { recordOutcome } from '../router/local-elo.js';
 import { shouldPlan, getPlanningPrompt, getExecutorModel, isExecutorStuck, toolCallSignature } from './planner.js';
@@ -1045,6 +1045,12 @@ export async function interactiveSession(
     // reuse the decision unless a real provider/payment failure deliberately
     // switches config.model to a fallback.
     let pinnedRouting: RoutingResult | undefined;
+    // Re-routes taken this turn because the gateway rejected the routed model
+    // id outright. Bounded so a chain that is dead end-to-end surfaces the
+    // error instead of cycling; each re-route is a $0 request anyway (the
+    // gateway rejects the id before any payment settles).
+    let deadModelReroutes = 0;
+    const MAX_DEAD_MODEL_REROUTES = 3;
     let routingCandidates: string[] = [];
     const turnIdleReference = lastSessionActivity;
     lastSessionActivity = Date.now();
@@ -1864,6 +1870,27 @@ export async function interactiveSession(
 
         const errMsg = (err as Error).message || '';
         const classified = classifyAgentError(errMsg);
+
+        // ── Dead model id (400 "Unknown model" / 404 / 410) ──
+        // Retrying can't help and a fallback chain that still names the id
+        // would just hand it back. When Auto routing picked it, feed the
+        // router's dead-rung kill-switch and re-route this same turn: the
+        // shared Router removes the id from every chain before its next
+        // selection. A concrete user-pinned model is left alone — the user
+        // chose it, and the classified suggestion already says /model.
+        if (classified.modelUnavailable && parseRoutingProfile(config.model)) {
+          const dead = resolvedModel;
+          if (markModelUnavailable(dead) && deadModelReroutes < MAX_DEAD_MODEL_REROUTES) {
+            deadModelReroutes++;
+            pinnedRouting = undefined;
+            logger.warn(`[franklin] ${dead} rejected by the gateway as unavailable — re-routing (${deadModelReroutes}/${MAX_DEAD_MODEL_REROUTES})`);
+            onEvent({
+              kind: 'text_delta',
+              text: `\n*${dead} is no longer served by the gateway — re-routing*\n`,
+            });
+            continue;
+          }
+        }
 
         // ── Media size error recovery (strip images/PDFs + retry) ──
         if (isMediaSizeError(errMsg) && recoveryAttempts < MAX_RECOVERY_ATTEMPTS) {

--- a/src/agent/tokens.ts
+++ b/src/agent/tokens.ts
@@ -222,7 +222,7 @@ const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
   'anthropic/claude-opus-5': 200_000,
   'anthropic/claude-opus-4.8': 200_000,
   'anthropic/claude-opus-4.7': 200_000,
-  'anthropic/claude-opus-4.6': 200_000,
+  'anthropic/claude-opus-4.6': 200_000, // hidden from /v1/models, still served (probed 2026-08-29)
   'anthropic/claude-opus-4.5': 200_000,
   'anthropic/claude-sonnet-5': 200_000,
   'anthropic/claude-sonnet-4.6': 200_000,
@@ -278,16 +278,20 @@ const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
   'xai/grok-4.5': 500_000,
   'xai/grok-4.3': 1_000_000,
   'xai/grok-build-0.1': 256_000,
+  // xAI 3.x / 4-0709 / 4-1-fast: hidden from /v1/models since 2026-08 but
+  // still served and charged (probed 2026-08-29) — keep their windows.
   'xai/grok-3': 131_072,
   'xai/grok-4-0709': 131_072,
   'xai/grok-4-1-fast-reasoning': 131_072,
   // Others
   'zai/glm-5.3': 1_000_000, // flagship 2026-08 — 1M context, always-on reasoning
+  'zai/glm-5.3-flash': 1_000_000, // 2026-08-29 catalog sync — 1M context, vision, $0.15/$0.5
   'zai/glm-5.2': 1_000_000, // flagship bump 2026-06 — context jumped 200K → 1M
   'zai/glm-5.1': 200_000,
   'zai/glm-5': 200_000,
   'zai/glm-5-turbo': 200_000,
   'moonshot/kimi-k3': 1_048_576,
+  // K2.x: hidden from /v1/models, still served (probed 2026-08-29).
   'moonshot/kimi-k2.7': 256_000,
   'moonshot/kimi-k2.6': 256_000,
   'moonshot/kimi-k2.5': 128_000,

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -45,7 +45,6 @@ export const MODEL_PRICING: Record<string, { input: number; output: number; perC
   'anthropic/claude-opus-5': { input: 5.0, output: 25.0 },
   'anthropic/claude-opus-4.8': { input: 5.0, output: 25.0 },
   'anthropic/claude-opus-4.7': { input: 5.0, output: 25.0 },
-  'anthropic/claude-opus-4.6': { input: 5.0, output: 25.0 },
   'anthropic/claude-opus-4.5': { input: 5.0, output: 25.0 },
   'anthropic/claude-sonnet-5': { input: 3.0, output: 15.0 }, // near-Opus at Sonnet cost, 1M ctx
   'anthropic/claude-sonnet-4.6': { input: 3.0, output: 15.0 },
@@ -55,7 +54,6 @@ export const MODEL_PRICING: Record<string, { input: number; output: number; perC
   // Kept for cost lookup on sessions recorded before the switch.
   'anthropic/claude-haiku-4.5-20251001': { input: 1.0, output: 5.0 },
   // OpenAI
-  'openai/gpt-5-nano': { input: 0.05, output: 0.4 },
   'openai/gpt-4.1-nano': { input: 0.1, output: 0.4 },
   'openai/gpt-4o-mini': { input: 0.15, output: 0.6 },
   'openai/gpt-5.4-nano': { input: 0.2, output: 1.25 },
@@ -73,7 +71,6 @@ export const MODEL_PRICING: Record<string, { input: number; output: number; perC
   'openai/gpt-4o': { input: 2.5, output: 10.0 },
   'openai/gpt-5.4': { input: 2.5, output: 15.0 },
   'openai/gpt-5.6-terra': { input: 2.0, output: 12.0 }, // balanced GPT-5.6 tier, 1M ctx (2026-07-30 cut)
-  'openai/o1-mini': { input: 1.1, output: 4.4 },
   'openai/o3-mini': { input: 1.1, output: 4.4 },
   'openai/o4-mini': { input: 1.1, output: 4.4 },
   'openai/o1': { input: 15.0, output: 60.0 },
@@ -99,17 +96,8 @@ export const MODEL_PRICING: Record<string, { input: number; output: number; perC
   'google/gemini-3.5-flash-lite': { input: 0.3, output: 2.5 },
   'google/gemini-3.6-flash': { input: 1.5, output: 7.5 }, // added upstream 2026-08-03 (base #329)
   'google/gemini-2.5-pro': { input: 1.25, output: 10.0 },
-  'google/gemini-3-pro-preview': { input: 2.0, output: 12.0 },
   'google/gemini-3.1-pro': { input: 2.0, output: 12.0 },
   // xAI
-  'xai/grok-4-fast': { input: 0.2, output: 0.5 },
-  'xai/grok-4-fast-reasoning': { input: 0.2, output: 0.5 },
-  'xai/grok-4-1-fast': { input: 0.2, output: 0.5 },
-  'xai/grok-4-1-fast-reasoning': { input: 0.2, output: 0.5 },
-  'xai/grok-4-0709': { input: 3.0, output: 15.0 }, // gateway lists $3/$15 (was mispriced here at $0.2/$1.5)
-  'xai/grok-3-mini': { input: 0.3, output: 0.5 },
-  'xai/grok-2-vision': { input: 2.0, output: 10.0 },
-  'xai/grok-3': { input: 3.0, output: 15.0 },
   'xai/grok-4.3': { input: 1.5, output: 4.0 },        // 1M ctx; demoted from flagship 2026-07-14
   'xai/grok-4.5': { input: 2.5, output: 9.0 },        // xAI flagship — 500K ctx (note: less than 4.3's 1M)
   'xai/grok-build-0.1': { input: 1.5, output: 3.0 },  // agentic coding, OpenRouter resale
@@ -123,7 +111,6 @@ export const MODEL_PRICING: Record<string, { input: number; output: number; perC
   // Minimax
   'minimax/minimax-m3': { input: 0.3, output: 1.2 },
   'minimax/minimax-m2.7': { input: 0.3, output: 1.2 },
-  'minimax/minimax-m2.5': { input: 0.3, output: 1.2 },
   // Qwen — Plus/Flash tiers added upstream 2026-08-03 (base #329).
   'qwen/qwen3.7-max': { input: 1.475, output: 4.425 },
   'qwen/qwen3.7-plus': { input: 0.32, output: 1.28 },
@@ -135,19 +122,46 @@ export const MODEL_PRICING: Record<string, { input: number; output: number; perC
   // context, multimodal (image+text), returns reasoning_content. Pricier
   // than the K2.x line it replaced ($3/$15 vs K2.7's $0.95/$4).
   'moonshot/kimi-k3': { input: 3.0, output: 15.0 },
-  // Retired K2.x line (kept for legacy session-cost records; the gateway no
-  // longer serves these and the `kimi`/`k2.*` shortcuts now resolve to K3).
-  'moonshot/kimi-k2.7': { input: 0.95, output: 4.0 },
-  'moonshot/kimi-k2.6': { input: 0.95, output: 4.0 },
-  'moonshot/kimi-k2.5': { input: 0.6, output: 3.0 },
-  'nvidia/kimi-k2.5': { input: 0.55, output: 2.5 },
   // PROMOTION (active ~2026-04): flat $0.001/call for all GLM models
   'zai/glm-5': { input: 1.0, output: 3.2 }, // flat promo ended 2026-06-06; raised upstream 2026-08-07
   'zai/glm-5.1': { input: 1.40, output: 4.40 }, // launch promo ended 2026-06-05 — per-token now
   'zai/glm-5.2': { input: 1.40, output: 4.40 }, // new flagship 2026-06 — 1M context, same per-token price as 5.1
   'zai/glm-5.3': { input: 1.40, output: 4.40 }, // flagship 2026-08 — 1M context, always-on reasoning, priced at 5.2
+  // GLM-5.3 Flash (catalog 2026-08-29): 1M context, vision, reasoning — the
+  // only GLM SKU tagged multimodal, at roughly a tenth of the flagship price.
+  'zai/glm-5.3-flash': { input: 0.15, output: 0.5 },
   'zai/glm-5-turbo': { input: 1.2, output: 4.0 }, // flat promo ended 2026-06-06 — per-token now
-  'zai/glm-5.1-turbo': { input: 1.2, output: 4.0 },  // client alias for zai/glm-5-turbo
+
+  // ── Hidden from /v1/models, still served ──
+  // None of these appear in GET /v1/models any more, but the gateway still
+  // routes and CHARGES for them: on 2026-08-29 every id marked (probed) below
+  // was called through the binary and answered. So they stay priced at list
+  // — a pinned `/model opus-4.6` or a router chain that still names one must
+  // cost correctly — and the picker keeps their shortcuts. The unmarked ids
+  // were not re-probed; they are kept so session-cost records written while
+  // they were live still price. The router's kill-switch
+  // (src/router/index.ts, markModelUnavailable) is what retires an id from
+  // routing, and it fires on a real 400/404/410, never on catalog absence.
+  'anthropic/claude-opus-4.6': { input: 5.0, output: 25.0 }, // (probed) superseded by 4.7 / 4.8 / 5 at the same price
+  'openai/gpt-5-nano': { input: 0.05, output: 0.4 }, // (probed)
+  'openai/o1-mini': { input: 1.1, output: 4.4 },
+  'google/gemini-3-pro-preview': { input: 2.0, output: 12.0 }, // GA'd as gemini-3.1-pro
+  'xai/grok-4-fast': { input: 0.2, output: 0.5 },
+  'xai/grok-4-fast-reasoning': { input: 0.2, output: 0.5 }, // (probed)
+  'xai/grok-4-1-fast': { input: 0.2, output: 0.5 },
+  'xai/grok-4-1-fast-reasoning': { input: 0.2, output: 0.5 }, // (probed)
+  'xai/grok-4-0709': { input: 3.0, output: 15.0 }, // (probed) gateway lists $3/$15 (was mispriced here at $0.2/$1.5)
+  'xai/grok-3-mini': { input: 0.3, output: 0.5 }, // (probed)
+  'xai/grok-2-vision': { input: 2.0, output: 10.0 },
+  'xai/grok-3': { input: 3.0, output: 15.0 }, // (probed)
+  'minimax/minimax-m2.5': { input: 0.3, output: 1.2 },
+  // K2.x (probed): the bare `kimi`/`k2.*` shortcuts resolve to K3, the
+  // explicit ids still answer.
+  'moonshot/kimi-k2.7': { input: 0.95, output: 4.0 },
+  'moonshot/kimi-k2.6': { input: 0.95, output: 4.0 },
+  'moonshot/kimi-k2.5': { input: 0.6, output: 3.0 },
+  'nvidia/kimi-k2.5': { input: 0.55, output: 2.5 },
+  'zai/glm-5.1-turbo': { input: 1.2, output: 4.0 }, // was a client alias for zai/glm-5-turbo
 };
 
 /** Opus pricing for savings calculations — tracks the current flagship. */

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -78,6 +78,12 @@ export interface RoutingContext {
   requiresTools?: boolean;
   requiresStructuredOutput?: boolean;
   systemPrompt?: string;
+  /**
+   * Extra model ids to treat as dead for this call only, on top of the
+   * process-wide set (see markModelUnavailable). Tests use this; hosts
+   * normally let the runtime observation feed the process-wide set.
+   */
+  unavailableModels?: readonly string[];
 }
 
 const SHARED_MODEL_PRICING = new Map(
@@ -90,6 +96,86 @@ const SHARED_MODEL_PRICING = new Map(
     },
   ]),
 );
+
+// ─── Dead-rung kill-switch ───
+//
+// router-core ships its tier chains as committed config, so a model that
+// leaves the gateway keeps its rung until a core release and a consumer
+// repin land — weeks, historically (the free/gpt-oss rungs 400'd for two
+// weeks before d7bc10c retired them). `options.unavailableModels` is the
+// core's answer: ids the host has observed dead are hard-removed from every
+// chain before selection, effective on the next request. Franklin feeds it
+// from three sources:
+//
+//   1. KNOWN_UNAVAILABLE_MODELS — ids the committed core config still
+//      references that the gateway has been observed to REJECT. Absence from
+//      GET /v1/models is NOT evidence: on 2026-08-29 every catalog-absent id
+//      the core config names (Opus 4.6, the K2.x line, the xAI 3.x / 4-0709 /
+//      4-fast family, gpt-5-nano) was probed through the binary and every one
+//      answered and was charged — the gateway hides them from the catalog
+//      but still serves them. Only add an id here after a real 400/404/410,
+//      and drop it once the core config itself stops naming it.
+//   2. QUARANTINED_MODELS — ids the catalog DOES list but Franklin refuses to
+//      route to, because the free pool answers for them with a substitute
+//      (the response's `model` field names a different model) and leaks
+//      thinking prose into content. Same "never promise a model the user
+//      doesn't get" rule the picker applies; see FREE_MODELS_BY_CATEGORY.
+//   3. Runtime observations — markModelUnavailable() is called by the agent
+//      loop when the gateway rejects a routed model id (400 "Unknown model",
+//      404, 410 — see AgentErrorInfo.modelUnavailable). Process-scoped: the
+//      next routing decision in this session never picks that id again.
+//
+// The core treats this as distinct from user-preference exclusion: a chain
+// whose every rung is dead keeps its config (the outage stays visible)
+// instead of fail-opening to something the host said is gone.
+const KNOWN_UNAVAILABLE_MODELS: readonly string[] = [
+  // Empty as of 2026-08-29 — see the probe note above. The free/gpt-oss and
+  // free/deepseek-v4-flash rungs that would have lived here were retired in
+  // the core itself (d7bc10c), which is the steady state this list waits for.
+];
+
+const QUARANTINED_MODELS: readonly string[] = [
+  // Catalogued free id; live probe 2026-08-29 answered as
+  // nvidia/nemotron-3-super-120b with the reasoning trace duplicated into
+  // `content`. The core uses it as the free backstop rung of every Auto
+  // chain — Franklin's chains end one rung earlier instead.
+  'nvidia/step-3.7-flash',
+];
+
+const observedUnavailable = new Set<string>();
+
+/**
+ * Record that the gateway rejected a model id outright (400 "Unknown model",
+ * 404, 410). Every later routing decision in this process removes it from
+ * the shared Router's chains. Idempotent; returns true the first time.
+ */
+export function markModelUnavailable(model: string | undefined | null): boolean {
+  if (!model || observedUnavailable.has(model)) return false;
+  observedUnavailable.add(model);
+  return true;
+}
+
+/** Ids the shared Router must not select: static, quarantined, and observed. */
+export function getUnavailableModels(extra?: readonly string[]): string[] {
+  return [...new Set([
+    ...KNOWN_UNAVAILABLE_MODELS,
+    ...QUARANTINED_MODELS,
+    ...observedUnavailable,
+    ...(extra ?? []),
+  ])];
+}
+
+export function isModelUnavailable(model: string | undefined | null): boolean {
+  if (!model) return false;
+  return observedUnavailable.has(model)
+    || KNOWN_UNAVAILABLE_MODELS.includes(model)
+    || QUARANTINED_MODELS.includes(model);
+}
+
+/** Test hook: forget runtime observations (the static lists stay). */
+export function resetUnavailableModels(): void {
+  observedUnavailable.clear();
+}
 
 function normalizeRoutingContext(context: boolean | RoutingContext): RoutingContext {
   return typeof context === 'boolean' ? { needsVision: context } : context;
@@ -133,6 +219,7 @@ const AUTO_TIERS: Record<Tier, { primary: string; fallback: string[] }> = {
       'anthropic/claude-opus-4.7',
       'openai/o3',
       'deepseek/deepseek-v4-pro',
+      // Hidden from /v1/models but still served (probed 2026-08-29).
       'xai/grok-4-1-fast-reasoning',
       'deepseek/deepseek-reasoner',
     ],
@@ -659,6 +746,7 @@ export function routeRequest(
           : {}),
         hasVision: normalizedContext.needsVision ?? false,
         requiresStructuredOutput: normalizedContext.requiresStructuredOutput ?? false,
+        unavailableModels: getUnavailableModels(normalizedContext.unavailableModels),
       },
     );
     const category = detectCategory(prompt, loadLearnedWeights()?.category_keywords).category;
@@ -794,7 +882,9 @@ export function getFallbackChain(
 // third: still DEGRADED at NVIDIA, kept as a genuinely different family for
 // the case where both Nemotron nano builds are down. The catalog's fifth free
 // id, step-3.7-flash, stays out of every chain — it leaks thinking prose into
-// content AND comes back served by nemotron-3-super-120b.
+// content AND comes back served by nemotron-3-super-120b (re-probed
+// 2026-08-29, unchanged). It is also QUARANTINED for the shared Router above,
+// which would otherwise use it as the free backstop rung of every Auto chain.
 const OMNI = 'nvidia/nemotron-3-nano-omni-30b-a3b-reasoning';
 
 const FREE_MODELS_BY_CATEGORY: Record<Category, string[]> = {

--- a/src/router/vision.ts
+++ b/src/router/vision.ts
@@ -25,6 +25,9 @@ const VISION_MODELS = new Set<string>([
   'anthropic/claude-opus-5',
   'anthropic/claude-opus-4.8',
   'anthropic/claude-opus-4.7',
+  // Hidden from /v1/models since 2026-08 but still served (probed through
+  // the binary 2026-08-29) — a pinned `opus-4.6` image turn must not be
+  // rerouted to a sibling the user didn't ask for.
   'anthropic/claude-opus-4.6',
   'anthropic/claude-opus-4.5',
   'anthropic/claude-sonnet-5',
@@ -64,17 +67,21 @@ const VISION_MODELS = new Set<string>([
   // xAI — grok-4-1-fast-reasoning stays out (text-only). Grok 4.5 and 4.3 are
   // both vision-capable in the catalog and were missing here until 2026-08-20:
   // `grok` resolves to 4.5, so every image turn on the xAI flagship was being
-  // rerouted to a "vision sibling" the user never asked for.
+  // rerouted to a "vision sibling" the user never asked for. grok-4-0709 and
+  // grok-3 are hidden from /v1/models but still served (probed 2026-08-29).
   'xai/grok-4.5',
   'xai/grok-4.3',
   'xai/grok-4-0709',
   'xai/grok-3',
-  // Moonshot — K3 is the Solana flagship; the K2.x compatibility line remains
-  // routable on both gateways and is also catalogued as multimodal.
+  // Moonshot — K3 is the flagship; the K2.x line is hidden from /v1/models
+  // but still served (probed 2026-08-29) and is catalogued as multimodal.
   'moonshot/kimi-k3',
   'moonshot/kimi-k2.7',
   'moonshot/kimi-k2.6',
   'moonshot/kimi-k2.5',
+  // Z.AI — GLM-5.3 Flash is the one GLM SKU the catalog tags as vision
+  // (2026-08-29 sync); GLM-5.3 / 5.2 / 5.1 are text + reasoning only.
+  'zai/glm-5.3-flash',
   // NVIDIA inference — Nemotron Nano VL is multimodal; deepseek/qwen-coder are
   // not. Llama 4 Maverick dropped 2026-07-14: it left the gateway catalog, and
   // listing it here contradicted routeRequest()'s own "maverick is text-only"

--- a/src/ui/model-picker.ts
+++ b/src/ui/model-picker.ts
@@ -31,6 +31,7 @@ export const MODEL_SHORTCUTS: Record<string, string> = {
   'opus-5': 'anthropic/claude-opus-5',
   'opus-4.8': 'anthropic/claude-opus-4.8',
   'opus-4.7': 'anthropic/claude-opus-4.7',
+  // Hidden from /v1/models since 2026-08, still served (probed 2026-08-29).
   'opus-4.6': 'anthropic/claude-opus-4.6',
   'opus-4.5': 'anthropic/claude-opus-4.5',
   haiku: 'anthropic/claude-haiku-4.5',
@@ -78,6 +79,7 @@ export const MODEL_SHORTCUTS: Record<string, string> = {
   'gpt-4o': 'openai/gpt-4o',
   'gpt-4o-mini': 'openai/gpt-4o-mini',
   codex: 'openai/gpt-5.3-codex',
+  // Hidden from /v1/models, still served (probed 2026-08-29).
   nano: 'openai/gpt-5-nano',
   mini: 'openai/gpt-5-mini',
   o3: 'openai/o3',
@@ -120,6 +122,10 @@ export const MODEL_SHORTCUTS: Record<string, string> = {
   'grok-4.5': 'xai/grok-4.5',
   'grok-4.3': 'xai/grok-4.3',
   'grok-build': 'xai/grok-build-0.1',
+  // grok-3 / grok-4-0709 / the grok-4-1-fast pair are hidden from
+  // /v1/models but still served and charged (probed 2026-08-29) — explicit
+  // pins keep resolving to the real ids. Note grok-3 and grok-4-0709 bill at
+  // $3/$15; `grok` (4.5) is the cheaper flagship.
   'grok-3': 'xai/grok-3',
   'grok-4': 'xai/grok-4-0709',
   'grok-fast': 'xai/grok-4-1-fast-reasoning',
@@ -223,6 +229,9 @@ export const MODEL_SHORTCUTS: Record<string, string> = {
   glm: 'zai/glm-5.2',
   'glm-5': 'zai/glm-5',
   'glm-5.3': 'zai/glm-5.3',
+  // GLM-5.3 Flash (2026-08-29 catalog sync): 1M ctx, vision, $0.15/$0.5.
+  'glm-5.3-flash': 'zai/glm-5.3-flash',
+  'glm-flash': 'zai/glm-5.3-flash',
   'glm-5.2': 'zai/glm-5.2',
   // GLM-5.1 demoted to a back-compat pin 2026-06 (flagship is 5.2) — still
   // routes for anyone who wants the 200K-context build explicitly.
@@ -418,9 +427,10 @@ export const PICKER_CATEGORIES: ModelCategory[] = [
     models: [
       { id: 'anthropic/claude-haiku-4.5',          shortcut: 'haiku',    label: 'Claude Haiku 4.5',    price: '$1/$5' },
       { id: 'openai/gpt-5-mini',                   shortcut: 'mini',     label: 'GPT-5 Mini',          price: '$0.25/$2' },
-      // `flash` now follows Gemini 3.6; this row keeps the cheap 2.5 build and
-      // labels itself with the explicit shortcut so the two can't drift apart.
-      { id: 'google/gemini-2.5-flash',             shortcut: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash', price: '$0.3/$2.5' },
+      // GLM-5.3 Flash took Gemini 2.5 Flash's row 2026-08-29: half the price,
+      // the same 1M context and vision, plus reasoning. `gemini-2.5-flash`
+      // still resolves — hide the row, keep the shortcut.
+      { id: 'zai/glm-5.3-flash',                   shortcut: 'glm-flash', label: 'GLM-5.3 Flash',      price: '$0.15/$0.5' },
       // Re-aliased to V4 Flash Chat upstream — context 1M, price 30% lower.
       { id: 'deepseek/deepseek-chat',              shortcut: 'deepseek', label: 'DeepSeek V4 Flash Chat', price: '$0.14/$0.28' },
       // Cheapest paid model on the gateway, and it still carries 1M context

--- a/test/local.mjs
+++ b/test/local.mjs
@@ -7154,8 +7154,12 @@ test('picker trim: shortcuts for hidden models still resolve (muscle-memory pres
   // flagship-promotion pattern as kimi → k2.7. Explicit pins still resolve.
   assert.equal(resolveModel('grok'), 'xai/grok-4.5');
   assert.equal(resolveModel('grok-4.3'), 'xai/grok-4.3');
+  // grok-3 / grok-4-0709 / grok-4-1-fast are hidden from /v1/models but
+  // still served (probed 2026-08-29) — explicit pins resolve to the real ids.
   assert.equal(resolveModel('grok-3'), 'xai/grok-3');
   assert.equal(resolveModel('grok-4'), 'xai/grok-4-0709');
+  assert.equal(resolveModel('grok-fast'), 'xai/grok-4-1-fast-reasoning');
+  assert.equal(resolveModel('grok-4.1'), 'xai/grok-4-1-fast-reasoning');
   assert.equal(resolveModel('grok-build'), 'xai/grok-build-0.1');
 });
 
@@ -10501,8 +10505,10 @@ test('vision helpers: isVisionModel allowlist matches curated set', async () => 
     'openai/o3',
     'google/gemini-3.1-pro',
     'google/gemini-2.5-flash',
+    'xai/grok-4.3',
     'xai/grok-4-0709',
     'moonshot/kimi-k3',
+    'zai/glm-5.3-flash',
     'nvidia/nemotron-nano-12b-v2-vl',
   ]) {
     assert.equal(isVisionModel(m), true, `${m} should be vision-capable`);
@@ -11516,4 +11522,166 @@ test('agent loop folds concurrent paid-tool spend on the stream-failure path (no
   // The post-drop cap check must also trip on tool spend, not only a dropped LLM charge.
   assert.match(src, /droppedPaidUsd > 0 \|\| droppedToolUsd > 0/,
     'the cap-after-drop guard must consider tool spend too');
+});
+
+
+// ─── 3.42.0: router-core d7bc10c + 2026-08-29 catalog sync ────────────────
+//
+// router-core ships its tier chains as committed config, and d7bc10c makes
+// nvidia/step-3.7-flash the free backstop rung of every Auto chain — an id
+// that answers as a different model with its reasoning leaked into content
+// (probed 2026-08-29). `options.unavailableModels` is the core's kill-switch
+// for a rung the host knows is bad; these tests pin that Franklin feeds it,
+// statically (the quarantine) and from runtime observation (a real gateway
+// rejection). Catalog absence alone is deliberately NOT a trigger: every
+// catalog-absent id the core config names still answered on 2026-08-29.
+
+const ROUTER_DEAD_IDS = [
+  'nvidia/step-3.7-flash',
+];
+
+const ROUTER_CORPUS = [
+  'hello',
+  'what is a closure in javascript',
+  'prove that the square root of 2 is irrational, step by step',
+  'refactor src/agent/loop.ts to extract the retry policy into its own module and add tests',
+  'compare BTC and ETH funding rates over the last 30 days and propose a pairs trade',
+  'summarize this 40k-token transcript: ' + 'lorem ipsum '.repeat(4000),
+  'write a haiku about autumn',
+  'debug: TypeError: cannot read properties of undefined (reading "map") at render (App.tsx:42)',
+  'extract every email address from the following text as a JSON array',
+];
+
+test('router kill-switch: Auto never selects an id the gateway no longer serves', async () => {
+  const { routeRequest, getUnavailableModels, resetUnavailableModels } = await import('../dist/router/index.js');
+  resetUnavailableModels();
+  const dead = new Set(getUnavailableModels());
+  for (const id of ROUTER_DEAD_IDS) {
+    assert.ok(dead.has(id), `${id} must be in the static unavailable set`);
+  }
+  for (const prompt of ROUTER_CORPUS) {
+    for (const ctx of [{}, { hasTools: true, toolNames: ['Read', 'Bash', 'Write'] }, { needsVision: true }, { maxOutputTokens: 60_000 }]) {
+      const r = routeRequest(prompt, 'auto', ctx);
+      assert.ok(!dead.has(r.model), `picked dead ${r.model} for ${JSON.stringify(prompt.slice(0, 40))}`);
+      for (const c of r.candidates ?? []) {
+        assert.ok(!dead.has(c), `dead ${c} survived in candidates for ${JSON.stringify(prompt.slice(0, 40))}`);
+      }
+    }
+  }
+});
+
+test('router kill-switch: a runtime observation removes the model from the next decision', async () => {
+  const { routeRequest, markModelUnavailable, isModelUnavailable, resetUnavailableModels } = await import('../dist/router/index.js');
+  resetUnavailableModels();
+  const prompt = 'refactor src/agent/loop.ts to extract the retry policy into its own module and add tests';
+  const before = routeRequest(prompt, 'auto', { hasTools: true, toolNames: ['Read', 'Edit', 'Bash'] });
+  assert.ok(before.model && before.model !== 'blockrun/auto');
+  assert.equal(isModelUnavailable(before.model), false);
+
+  // First observation is recorded; a repeat is a no-op (the loop uses the
+  // boolean to bound re-routes to one per dead id).
+  assert.equal(markModelUnavailable(before.model), true);
+  assert.equal(markModelUnavailable(before.model), false);
+  assert.equal(isModelUnavailable(before.model), true);
+
+  const after = routeRequest(prompt, 'auto', { hasTools: true, toolNames: ['Read', 'Edit', 'Bash'] });
+  assert.notEqual(after.model, before.model, 'the dead id must not be selected again');
+  assert.ok(!(after.candidates ?? []).includes(before.model), 'the dead id must leave the recovery chain too');
+  // The survivor is what the chain would have fallen back to — a real model.
+  assert.ok(after.model.includes('/'), `expected a gateway id, got ${after.model}`);
+
+  resetUnavailableModels();
+  assert.equal(isModelUnavailable(before.model), false);
+  const restored = routeRequest(prompt, 'auto', { hasTools: true, toolNames: ['Read', 'Edit', 'Bash'] });
+  assert.equal(restored.model, before.model, 'reset must restore the original decision');
+});
+
+test('router kill-switch: per-call unavailableModels context is honored', async () => {
+  const { routeRequest, resetUnavailableModels } = await import('../dist/router/index.js');
+  resetUnavailableModels();
+  const prompt = 'what is a closure in javascript';
+  const base = routeRequest(prompt, 'auto', {});
+  const routed = routeRequest(prompt, 'auto', { unavailableModels: [base.model] });
+  assert.notEqual(routed.model, base.model);
+  assert.ok(!(routed.candidates ?? []).includes(base.model));
+  // Scoped to the call — the process-wide set is untouched.
+  assert.equal(routeRequest(prompt, 'auto', {}).model, base.model);
+});
+
+test('router kill-switch: the free profile is not affected by the shared Router set', async () => {
+  const { routeRequest, markModelUnavailable, resetUnavailableModels } = await import('../dist/router/index.js');
+  resetUnavailableModels();
+  const r = routeRequest('hello', 'free');
+  assert.equal(r.model, 'nvidia/nemotron-nano-9b-v2');
+  assert.ok(!r.candidates.includes('nvidia/step-3.7-flash'), 'quarantined free id must not be in the free chain');
+  markModelUnavailable('nvidia/nemotron-nano-9b-v2');
+  // The free chain is Franklin's own (pickFreeFallback walks it with the
+  // per-turn failed set); the kill-switch only feeds the shared Router.
+  assert.equal(routeRequest('hello', 'free').model, 'nvidia/nemotron-nano-9b-v2');
+  resetUnavailableModels();
+});
+
+test('error classifier: a rejected model id is flagged modelUnavailable, request-shape errors are not', async () => {
+  const { classifyAgentError } = await import('../dist/agent/error-classifier.js');
+  const unknown = classifyAgentError('HTTP 400: {"error":"Unknown model: xai/grok-4-1-fast-reasoning"}');
+  assert.equal(unknown.category, 'schema');
+  assert.equal(unknown.modelUnavailable, true);
+  assert.equal(unknown.isTransient, false);
+
+  const gone = classifyAgentError('HTTP 410 Gone: model nvidia/deepseek-v4-flash has been retired by the provider');
+  assert.equal(gone.modelUnavailable, true);
+
+  const bare410 = classifyAgentError('410: this model is no longer served');
+  assert.equal(bare410.modelUnavailable, true);
+
+  // Same category (schema), but the id is fine — the loop must not re-route.
+  const shape = classifyAgentError('400 invalid request: array schema missing items');
+  assert.equal(shape.category, 'schema');
+  assert.equal(shape.modelUnavailable, undefined);
+
+  // A 4100-token count or a 410 in a request id is not an HTTP 410.
+  assert.equal(classifyAgentError('prompt is too long: 4100 tokens over the limit').modelUnavailable, undefined);
+  assert.equal(classifyAgentError('500 internal server error (req_410)').modelUnavailable, undefined);
+});
+
+test('catalog sync 2026-08-29: GLM-5.3 Flash is priced, sized, vision-tagged and pickable', async () => {
+  const { MODEL_PRICING } = await import('../dist/pricing.js');
+  const { getContextWindow } = await import('../dist/agent/tokens.js');
+  const { isVisionModel } = await import('../dist/router/vision.js');
+  const { resolveModel, PICKER_CATEGORIES } = await import('../dist/ui/model-picker.js');
+  assert.deepEqual(MODEL_PRICING['zai/glm-5.3-flash'], { input: 0.15, output: 0.5 });
+  assert.equal(getContextWindow('zai/glm-5.3-flash'), 1_000_000);
+  assert.equal(isVisionModel('zai/glm-5.3-flash'), true);
+  assert.equal(isVisionModel('zai/glm-5.3'), false, 'only the Flash SKU is multimodal in the catalog');
+  assert.equal(resolveModel('glm-flash'), 'zai/glm-5.3-flash');
+  assert.equal(resolveModel('glm-5.3-flash'), 'zai/glm-5.3-flash');
+  const ids = PICKER_CATEGORIES.flatMap((c) => c.models.map((m) => m.id));
+  assert.ok(ids.includes('zai/glm-5.3-flash'), 'GLM-5.3 Flash earns a budget row');
+  assert.ok(!ids.includes('google/gemini-2.5-flash'), 'Gemini 2.5 Flash gave up its row (shortcut stays)');
+  assert.equal(resolveModel('gemini-2.5-flash'), 'google/gemini-2.5-flash');
+});
+
+test('catalog sync 2026-08-29: hidden-but-served ids stay priced, routable and pinnable', async () => {
+  // Every one of these is absent from GET /v1/models and every one answered
+  // (and was charged) through the binary on 2026-08-29. Absence from the
+  // catalog must not retire an id anywhere: not from pricing (the charge is
+  // real), not from the router (the core config still names them), not from
+  // the picker's explicit pins.
+  const { MODEL_PRICING } = await import('../dist/pricing.js');
+  const { isModelUnavailable, resetUnavailableModels } = await import('../dist/router/index.js');
+  const { resolveModel } = await import('../dist/ui/model-picker.js');
+  resetUnavailableModels();
+  const served = {
+    'anthropic/claude-opus-4.6': 'opus-4.6',
+    'xai/grok-4-0709': 'grok-4',
+    'xai/grok-3': 'grok-3',
+    'xai/grok-4-1-fast-reasoning': 'grok-fast',
+    'moonshot/kimi-k2.7': 'moonshot/kimi-k2.7',
+    'openai/gpt-5-nano': 'nano',
+  };
+  for (const [id, pin] of Object.entries(served)) {
+    assert.ok(MODEL_PRICING[id], `${id} must stay priced — the gateway still charges for it`);
+    assert.equal(isModelUnavailable(id), false, `${id} must not be pre-declared dead on catalog absence`);
+    assert.equal(resolveModel(pin), id, `${pin} must keep resolving to the real id`);
+  }
 });


### PR DESCRIPTION
## Franklin Agent 3.42.0 — router-core d7bc10c, and the dead-rung kill-switch is wired

**The shared Router can now be told a model is gone — and Franklin tells it.**
`@blockrun/router-core` moves from `6a790eb` to `d7bc10c` (eleven commits):
the `free/gpt-oss-120b` / `-20b` rungs that had been 400-ing for two weeks are
retired in the core, `free/deepseek-v4-flash` (NVIDIA EOL, 410) leaves the eco
chain, and `options.unavailableModels` arrives — ids the host has observed
dead are hard-removed from every tier chain before selection, never restored
by an eligibility fail-open, effective on the next request instead of after a
core release and two consumer repins. Franklin now feeds it from two sources.
The first is a **quarantine**: `d7bc10c` makes `nvidia/step-3.7-flash` the
free backstop rung of every Auto chain, and a live probe today still came back
served by `nvidia/nemotron-3-super-120b` with the reasoning trace duplicated
into `content` — the same "never promise a model the user doesn't get" rule
the picker already applies, so Franklin's Auto chains end one rung earlier.
The second is **runtime observation**: the error classifier flags a rejected
model id (`400 Unknown model`, 404, or a 410 provider EOL) as
`modelUnavailable`, distinct from the request-shape errors it shares a
category with, and when Auto routing picked that id the loop marks it dead
(`markModelUnavailable`) and re-routes the same turn — bounded to three
re-routes per turn so a chain that is dead end-to-end surfaces the error
instead of cycling. A concrete user-pinned model is left alone; the user chose
it, and the suggestion already says `/model`.

**Absence from `/v1/models` is not death, and this release nearly got that
wrong.** The catalog no longer lists Opus 4.6, the Kimi K2.x line, the xAI
3.x / 4-0709 / 4-fast family or `gpt-5-nano`, and the core config still names
every one of them. Before declaring them dead they were all called through the
binary: every one answered and every one was charged. So nothing is retired on
catalog grounds — the static dead list ships empty with the probe recorded
beside it, the explicit picker pins keep resolving to the real ids, their
pricing stays at list (regrouped under one "hidden from `/v1/models`, still
served" heading, each probed id marked), and the vision allowlist keeps them.
One observed number worth knowing if you pin them: a 12-token-in /
13-token-out probe cost **$0.097 on `xai/grok-3` and `xai/grok-4-0709`** —
`grok` (4.5) is the cheaper flagship.

**GLM-5.3 Flash lands in every table.** The one model the catalog gained since
3.40.0: $0.15/$0.5, 1M context, and the only GLM SKU tagged multimodal. It is
priced, sized, on the vision allowlist, pinnable as `glm-flash` /
`glm-5.3-flash`, and takes Gemini 2.5 Flash's row in the Budget picker (half
the price, same 1M and vision, plus reasoning; `gemini-2.5-flash` still
resolves — hide the row, keep the shortcut).

Also: the gateway API brief the agent carries now lists `zai/glm-5.3-flash`
among its verified-live examples (2026-08-29); the plugin-SDK tier table and
the live e2e checklist no longer point at `nvidia/qwen3-coder-480b`, retired
months ago; brand numbers re-synced from the canonical artifact (72 visible
chat models). Seven new local tests pin the kill-switch (static, per-call and
observed), the classifier flag, the GLM-5.3 Flash tables, and the
hidden-but-served invariant.

Tests: `npm test` — 655/655 pass. Live probes through the binary on 2026-08-29: 11 catalog-absent ids all answered (see CHANGELOG); `nvidia/step-3.7-flash` still substituted.