### PR TITLE
release: 3.42.1 — the deep pass after 3.42.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## Franklin Agent 3.42.1 — the deep pass after 3.42.0: three things the sync missed
+
+**An image turn on Auto could land on a model that cannot see.** The shared
+Router decides vision eligibility from its own capability snapshot, and that
+snapshot fails *open* for any id it has no entry for — 36 gateway chat ids as
+of today, including text-only models that sit in the core's evidence lists
+(`zai/glm-5.2` in long-context, for one). Franklin's Auto branch trusted the
+pick as-is; the manual-mode vision guard only ran for user-pinned models. Two
+fixes: Franklin now hands the core a capability override whose
+`supportsVision` comes from its own maintained allowlist (the core also
+disagreed with it on `gpt-5-mini`, `o3` and `grok-4-0709`, all of which accept
+images), and the Auto branch walks the core's recovery chain for the first
+sighted model before falling back to the family sibling — so a knocked-out
+pick still recovers to a model with eyes.
+
+**Two ids in the core's SIMPLE chains had no price.** `xai/grok-4-1-fast-non-
+reasoning` and `xai/grok-4-fast-non-reasoning` are served and were charged
+today, yet Franklin's table had only their reasoning siblings: the UI
+reported them as $0 while the wallet paid, and the portfolio scorer — which
+treats an unpriced id as infinitely expensive — could never prefer them over
+a priced rung. Priced at the pair's $0.2/$0.5, with context windows for the
+whole hidden xAI fast family.
+
+**The proxy never fed the kill-switch.** Its fallback chain only retries
+429/5xx, so a routed id the gateway rejects outright (`400 Unknown model`,
+404, 410) passed straight through to the client with nothing learned. The
+4xx intercept now classifies the error and, for routed requests only, marks
+the id dead for the process — a client that pinned the id by name is left
+alone.
+
+Also verified today and deliberately *not* changed: every `free/*` id the
+core still lists in its capability table 400s (`Unknown model`), but none of
+them sits in a chain, so nothing can select them; the static dead list stays
+empty. Three new tests cover the vision guard through the recovery chain, the
+xAI pricing, and the proxy hook.
+
 ## Franklin Agent 3.42.0 — router-core d7bc10c, and the dead-rung kill-switch is wired
 
 **The shared Router can now be told a model is gone — and Franklin tells it.**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockrun/franklin",
-  "version": "3.42.0",
+  "version": "3.42.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockrun/franklin",
-      "version": "3.42.0",
+      "version": "3.42.1",
       "license": "Apache-2.0",
       "workspaces": [
         "apps/desktop"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockrun/franklin",
-  "version": "3.42.0",
+  "version": "3.42.1",
   "description": "Franklin Agent — The AI agent with a wallet. Spends USDC autonomously to get real work done. Pay per action, no subscriptions.",
   "type": "module",
   "exports": {

--- a/src/agent/tokens.ts
+++ b/src/agent/tokens.ts
@@ -281,8 +281,12 @@ const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
   // xAI 3.x / 4-0709 / 4-1-fast: hidden from /v1/models since 2026-08 but
   // still served and charged (probed 2026-08-29) — keep their windows.
   'xai/grok-3': 131_072,
+  'xai/grok-3-mini': 131_072,
   'xai/grok-4-0709': 131_072,
   'xai/grok-4-1-fast-reasoning': 131_072,
+  'xai/grok-4-1-fast-non-reasoning': 131_072,
+  'xai/grok-4-fast-reasoning': 131_072,
+  'xai/grok-4-fast-non-reasoning': 131_072,
   // Others
   'zai/glm-5.3': 1_000_000, // flagship 2026-08 — 1M context, always-on reasoning
   'zai/glm-5.3-flash': 1_000_000, // 2026-08-29 catalog sync — 1M context, vision, $0.15/$0.5

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -150,6 +150,13 @@ export const MODEL_PRICING: Record<string, { input: number; output: number; perC
   'xai/grok-4-fast-reasoning': { input: 0.2, output: 0.5 }, // (probed)
   'xai/grok-4-1-fast': { input: 0.2, output: 0.5 },
   'xai/grok-4-1-fast-reasoning': { input: 0.2, output: 0.5 }, // (probed)
+  // The two non-reasoning ids sit in the shared Router's SIMPLE chains and
+  // were charged today, yet had no row here — Franklin reported them as $0
+  // and the portfolio scorer, which treats an unpriced id as infinitely
+  // expensive, could never pick them over a priced rung. Priced with their
+  // reasoning siblings (xAI bills the pair identically).
+  'xai/grok-4-1-fast-non-reasoning': { input: 0.2, output: 0.5 }, // (probed)
+  'xai/grok-4-fast-non-reasoning': { input: 0.2, output: 0.5 }, // (probed)
   'xai/grok-4-0709': { input: 3.0, output: 15.0 }, // (probed) gateway lists $3/$15 (was mispriced here at $0.2/$1.5)
   'xai/grok-3-mini': { input: 0.3, output: 0.5 }, // (probed)
   'xai/grok-2-vision': { input: 2.0, output: 10.0 },

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -28,8 +28,10 @@ import {
   isVisionModel,
   messagesNeedVision,
   pickVisionSibling,
+  markModelUnavailable,
   type RoutingProfile,
 } from '../router/index.js';
+import { classifyAgentError } from '../agent/error-classifier.js';
 import { estimateCost } from '../pricing.js';
 import { getMaxOutputTokens } from '../agent/optimize.js';
 import { VERSION } from '../config.js';
@@ -615,6 +617,16 @@ export function createProxy(options: ProxyOptions): http.Server {
             } else {
               // Wrap in Anthropic error format
               const errorMsg = parsed.error?.message || parsed.message || rawText.slice(0, 500);
+              // The proxy's fallback chain only retries 429/5xx, so a routed
+              // id the gateway rejects outright (400 "Unknown model", 404,
+              // 410) reaches here untouched. Feed the router's dead-rung
+              // kill-switch so the next routed request skips it; a client
+              // that pinned the id by name is left alone.
+              if (routerCandidates.length > 0 && classifyAgentError(String(errorMsg)).modelUnavailable) {
+                if (markModelUnavailable(finalModel)) {
+                  logger.warn(`[franklin] ${finalModel} rejected by the gateway as unavailable — removed from routing for this process`);
+                }
+              }
               errorBody = JSON.stringify({
                 type: 'error',
                 error: {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -13,8 +13,10 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import {
+  DEFAULT_MODEL_CAPABILITIES as SHARED_MODEL_CAPABILITIES_BASE,
   DEFAULT_ROUTING_CONFIG as SHARED_ROUTING_CONFIG,
   route as routeWithSharedCore,
+  type ModelCapabilities,
   type TaskType,
 } from '@blockrun/router-core';
 import { MODEL_PRICING, OPUS_PRICING } from '../pricing.js';
@@ -23,7 +25,7 @@ import { detectCategory, mapCategoryToTier, type Category } from './categories.j
 import { selectModel } from './selector.js';
 import type { LearnedWeights } from './selector.js';
 import { computeLocalElo, blendElo } from './local-elo.js';
-import { isVisionModel } from './vision.js';
+import { isVisionModel, pickVisionSibling } from './vision.js';
 
 export { isVisionModel, messageNeedsVision, messagesNeedVision, pickVisionSibling } from './vision.js';
 
@@ -176,6 +178,22 @@ export function isModelUnavailable(model: string | undefined | null): boolean {
 export function resetUnavailableModels(): void {
   observedUnavailable.clear();
 }
+
+// The core's capability snapshot decides vision eligibility inside the
+// portfolio, but it lags the catalog (36 gateway chat ids have no entry as of
+// 2026-08-29, and it disagrees with Franklin's allowlist on gpt-5-mini / o3 /
+// grok-4-0709, all of which accept images). Franklin's allowlist in vision.ts
+// is the maintained source, so its verdict overrides `supportsVision` on
+// every entry the core knows. Ids the core does not know fail OPEN inside
+// the core (`isEligible` returns true) — that gap is closed by the
+// post-selection guard in routeRequest, not by inventing context/output
+// numbers here that would silently change eligibility.
+const SHARED_MODEL_CAPABILITIES: Readonly<Record<string, ModelCapabilities>> = Object.fromEntries(
+  Object.entries(SHARED_MODEL_CAPABILITIES_BASE).map(([id, caps]) => [
+    id,
+    { ...caps, supportsVision: isVisionModel(id) },
+  ]),
+);
 
 function normalizeRoutingContext(context: boolean | RoutingContext): RoutingContext {
   return typeof context === 'boolean' ? { needsVision: context } : context;
@@ -737,6 +755,7 @@ export function routeRequest(
           strategy: process.env.FRANKLIN_ROUTER_STRATEGY === 'rules' ? 'rules' : 'portfolio',
         },
         modelPricing: SHARED_MODEL_PRICING,
+        modelCapabilities: SHARED_MODEL_CAPABILITIES,
         routingProfile: 'auto',
         hasTools: normalizedContext.hasTools ?? toolNames.length > 0,
         toolCount: toolNames.length,
@@ -750,14 +769,30 @@ export function routeRequest(
       },
     );
     const category = detectCategory(prompt, loadLearnedWeights()?.category_keywords).category;
+    let model = decision.model;
+    let candidates = decision.candidates ?? [decision.model];
+    const signals: string[] = [decision.routerVersion ?? decision.method, ...(decision.taskType ? [decision.taskType] : [])];
+    // Vision is a hard requirement, and the core fails open for any id
+    // missing from its capability snapshot (see SHARED_MODEL_CAPABILITIES).
+    // Before this guard an image turn could land on a text-only model the
+    // core simply had no opinion about — zai/glm-5.2 sits in the long-context
+    // evidence list, for instance — and the model would then hallucinate
+    // from the `Image file: <path>` stub. Walk the core's own recovery chain
+    // for the first model that can see; fall back to the family sibling.
+    if (normalizedContext.needsVision && !isVisionModel(model)) {
+      const sighted = candidates.filter(isVisionModel);
+      model = sighted[0] ?? pickVisionSibling(model);
+      candidates = sighted.length > 0 ? sighted : [model];
+      signals.push('vision-required');
+    }
     return {
-      model: decision.model,
+      model,
       tier: decision.tier,
       confidence: decision.confidence,
-      signals: [decision.routerVersion ?? decision.method, ...(decision.taskType ? [decision.taskType] : [])],
-      savings: decision.savings,
+      signals,
+      savings: model === decision.model ? decision.savings : computeSavings(model),
       category,
-      candidates: decision.candidates ?? [decision.model],
+      candidates,
       taskType: decision.taskType,
       routerVersion: decision.routerVersion,
       reasoning: decision.reasoning,

--- a/test/local.mjs
+++ b/test/local.mjs
@@ -11698,3 +11698,43 @@ test('catalog sync 2026-08-29: hidden-but-served ids stay priced, routable and p
     assert.equal(resolveModel(pin), id, `${pin} must keep resolving to the real id`);
   }
 });
+
+
+test('router vision guard: Auto never lands an image turn on a text-only model, even through the recovery chain', async () => {
+  const { routeRequest, resetUnavailableModels } = await import('../dist/router/index.js');
+  const { isVisionModel } = await import('../dist/router/vision.js');
+  resetUnavailableModels();
+  const prompts = [
+    'what is in this screenshot? ./shot.png',
+    'read chart.png and tell me the trend',
+    'summarize this 40k-token document with the attached diagram.png: ' + 'lorem ipsum '.repeat(4000),
+    'refactor the component shown in ui.png and add tests',
+    'which option is correct in quiz.jpg? A, B, C or D — think step by step',
+  ];
+  for (const prompt of prompts) {
+    const r = routeRequest(prompt, 'auto', { needsVision: true, hasTools: true, toolNames: ['Read', 'Bash'] });
+    assert.ok(isVisionModel(r.model), `${r.model} cannot see images (prompt: ${prompt.slice(0, 40)})`);
+    for (const c of r.candidates ?? []) {
+      assert.ok(isVisionModel(c), `recovery chain offered text-only ${c}`);
+    }
+    // Knock out the pick and the next rung must still be sighted.
+    const next = routeRequest(prompt, 'auto', { needsVision: true, hasTools: true, toolNames: ['Read', 'Bash'], unavailableModels: [r.model] });
+    assert.ok(isVisionModel(next.model), `${next.model} cannot see images after ${r.model} was removed`);
+  }
+});
+
+test('catalog sync 2026-08-29: the xAI non-reasoning fast ids in the core chains are priced', async () => {
+  const { MODEL_PRICING } = await import('../dist/pricing.js');
+  const { getContextWindow } = await import('../dist/agent/tokens.js');
+  for (const id of ['xai/grok-4-1-fast-non-reasoning', 'xai/grok-4-fast-non-reasoning']) {
+    assert.deepEqual(MODEL_PRICING[id], { input: 0.2, output: 0.5 }, `${id} was charged today; it must not estimate as $0`);
+    assert.equal(getContextWindow(id), 131_072);
+  }
+});
+
+test('proxy: a gateway-rejected routed id feeds the dead-rung kill-switch', async () => {
+  const src = readFileSync(new URL('../src/proxy/server.ts', import.meta.url), 'utf-8');
+  assert.match(src, /routerCandidates\.length > 0 && classifyAgentError\(String\(errorMsg\)\)\.modelUnavailable/,
+    'the 4xx intercept must classify the error and only act on routed requests');
+  assert.match(src, /markModelUnavailable\(finalModel\)/);
+});


### PR DESCRIPTION

**An image turn on Auto could land on a model that cannot see.** The shared
Router decides vision eligibility from its own capability snapshot, and that
snapshot fails *open* for any id it has no entry for — 36 gateway chat ids as
of today, including text-only models that sit in the core's evidence lists
(`zai/glm-5.2` in long-context, for one). Franklin's Auto branch trusted the
pick as-is; the manual-mode vision guard only ran for user-pinned models. Two
fixes: Franklin now hands the core a capability override whose
`supportsVision` comes from its own maintained allowlist (the core also
disagreed with it on `gpt-5-mini`, `o3` and `grok-4-0709`, all of which accept
images), and the Auto branch walks the core's recovery chain for the first
sighted model before falling back to the family sibling — so a knocked-out
pick still recovers to a model with eyes.

**Two ids in the core's SIMPLE chains had no price.** `xai/grok-4-1-fast-non-
reasoning` and `xai/grok-4-fast-non-reasoning` are served and were charged
today, yet Franklin's table had only their reasoning siblings: the UI
reported them as $0 while the wallet paid, and the portfolio scorer — which
treats an unpriced id as infinitely expensive — could never prefer them over
a priced rung. Priced at the pair's $0.2/$0.5, with context windows for the
whole hidden xAI fast family.

**The proxy never fed the kill-switch.** Its fallback chain only retries
429/5xx, so a routed id the gateway rejects outright (`400 Unknown model`,
404, 410) passed straight through to the client with nothing learned. The
4xx intercept now classifies the error and, for routed requests only, marks
the id dead for the process — a client that pinned the id by name is left
alone.

Also verified today and deliberately *not* changed: every `free/*` id the
core still lists in its capability table 400s (`Unknown model`), but none of
them sits in a chain, so nothing can select them; the static dead list stays
empty. Three new tests cover the vision guard through the recovery chain, the
xAI pricing, and the proxy hook.

Tests: `npm test` — 670/670 pass.