### PR TITLE
fix(wallet): hold reservation on ambiguous x402 settlement (#128)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "desktop:package:win": "npm run dist:win --workspace @blockrun/franklin-desktop",
     "dev": "tsc --watch",
     "start": "node dist/index.js",
-    "test": "npm run build && node --test --test-concurrency=4 --test-reporter=spec test/local.mjs test/serve-security.local.mjs test/skills.local.mjs test/repair.mjs test/model-resolver.mjs test/exa.local.mjs test/audit-batch.local.mjs test/polymarket.local.mjs test/market.local.mjs test/hooks.local.mjs test/scheduler.local.mjs test/trade-plan.local.mjs test/goal.local.mjs test/memory.local.mjs test/agent-host.local.mjs",
+    "test": "npm run build && node --test --test-concurrency=4 --test-reporter=spec test/local.mjs test/serve-security.local.mjs test/skills.local.mjs test/repair.mjs test/model-resolver.mjs test/exa.local.mjs test/audit-batch.local.mjs test/polymarket.local.mjs test/market.local.mjs test/hooks.local.mjs test/scheduler.local.mjs test/trade-plan.local.mjs test/goal.local.mjs test/memory.local.mjs test/agent-host.local.mjs test/reservation.local.mjs",
     "test:e2e": "npm run build && node --test --test-reporter=spec test/e2e.mjs",
     "e2e:polymarket:readonly": "npm run build && node scripts/polymarket-e2e-readonly.mjs",
     "test:free-models": "npm run build && node --test --test-reporter=spec test/free-model-matrix.mjs",

--- a/src/tools/modal.ts
+++ b/src/tools/modal.ts
@@ -38,7 +38,7 @@ import {
 } from '@blockrun/llm';
 import type { CapabilityHandler, CapabilityResult, ExecutionScope } from '../agent/types.js';
 import { loadChain, API_URLS, VERSION } from '../config.js';
-import { walletReservation, type ReservationToken } from '../wallet/reservation.js';
+import { walletReservation, AMBIGUOUS_GRACE_MS, type ReservationToken } from '../wallet/reservation.js';
 import { recordUsage } from '../stats/tracker.js';
 import { logger } from '../logger.js';
 
@@ -98,6 +98,12 @@ class SessionSandboxTracker {
 export const sessionSandboxTracker = new SessionSandboxTracker();
 
 // ─── x402 payment signing — same shape as imagegen's helper ───────────────
+
+/** Indirection so tests can stub the signer without a funded wallet. */
+let paymentSigner: typeof signPayment = (...args) => signPayment(...args);
+export function _setPaymentSignerForTests(fn: typeof signPayment | null): void {
+  paymentSigner = fn ?? ((...args) => signPayment(...args));
+}
 
 async function signPayment(
   response: Response,
@@ -177,12 +183,15 @@ async function extractPaymentReq(response: Response): Promise<string | null> {
  *
  * `reservation` is the caller's wallet hold for this call. If the signed
  * (paid) request has been dispatched and the call then aborts or times out
- * before a response, the outcome is ambiguous — the gateway may already have
- * settled the payment. The hold is marked ambiguous so the reservation layer
- * keeps counting it (see reservation.ts) instead of the caller's `finally`
- * releasing it as if nothing was spent.
+ * before a response, or the response arrives but its body is cut off, the
+ * outcome is ambiguous — the gateway may already have settled the payment.
+ * The hold is marked ambiguous so the reservation layer keeps counting it
+ * (see reservation.ts) instead of the caller's `finally` releasing it as if
+ * nothing was spent. Failures that provably never left this machine (signal
+ * already aborted before dispatch, DNS / connection-refused) are NOT
+ * ambiguous and release normally.
  */
-async function postWithPayment(
+export async function postWithPayment(
   endpoint: string,
   body: Record<string, unknown>,
   resourceDescription: string,
@@ -206,10 +215,14 @@ async function postWithPayment(
     let response = await fetch(endpoint, { method: 'POST', signal: ctrl.signal, headers, body: payload });
 
     if (response.status === 402) {
-      const paymentHeaders = await signPayment(response, chain, endpoint, resourceDescription);
+      const paymentHeaders = await paymentSigner(response, chain, endpoint, resourceDescription);
       if (!paymentHeaders) {
         return { ok: false, status: 402, body: { error: 'payment signing failed' }, raw: '' };
       }
+      // Signing can take a while (wallet load, Solana RPC). If the budget
+      // expired meanwhile, fetch rejects before writing a byte — that is a
+      // definite non-payment, not an ambiguous one.
+      if (ctrl.signal.aborted) throw signalError(ctrl.signal);
       paymentDispatched = true;
       response = await fetch(endpoint, {
         method: 'POST',
@@ -219,15 +232,25 @@ async function postWithPayment(
       });
     }
 
-    const raw = await response.text().catch(() => '');
+    let raw = '';
+    try {
+      raw = await response.text();
+    } catch (err) {
+      // A paid 2xx whose body was cut off (abort mid-stream) is still a
+      // settled payment with an unknown result — e.g. a sandbox we were never
+      // told the id of. Surface it instead of returning ok:true with {}.
+      if (paymentDispatched) throw err;
+    }
     let parsed: Record<string, unknown> = {};
     try { parsed = raw ? JSON.parse(raw) : {}; } catch { /* leave as {} */ }
     return { ok: response.ok, status: response.status, body: parsed, raw };
   } catch (err) {
-    if (paymentDispatched && reservation) {
+    if (paymentDispatched && reservation && !definitelyNotSent(err)) {
       // Signed request went out; abort/timeout hit before we saw the result.
       // Money may be gone — keep the hold counted rather than releasing it.
-      walletReservation.markAmbiguous(reservation);
+      // Window = this call's own timeout (the gateway may still be running
+      // the paid work and settle when it finishes) + settlement margin.
+      walletReservation.markAmbiguous(reservation, timeoutMs + AMBIGUOUS_GRACE_MS);
       logger.warn(
         `[franklin] Modal payment outcome ambiguous (${(err as Error).message}); ` +
         `holding ${reservation.amountUsd.toFixed(4)} USDC reservation until balance refresh`,
@@ -241,6 +264,41 @@ async function postWithPayment(
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────
+
+/** Explain why hold() refused, so the agent does not loop on "wait". */
+function describeHeadroom(): string {
+  const snap = walletReservation.snapshot();
+  const parts: string[] = [];
+  if (snap.count > 0) parts.push(`${snap.count} in-flight paid call(s) hold ${fmtUsd(snap.totalUsd - snap.ambiguousUsd)}`);
+  if (snap.ambiguousCount > 0) {
+    parts.push(
+      `${fmtUsd(snap.ambiguousUsd)} is held for ${snap.ambiguousCount} recent payment(s) whose settlement is ` +
+      `unconfirmed (released automatically after the on-chain balance refreshes)`,
+    );
+  }
+  if (parts.length === 0) return 'Fund the wallet.';
+  return parts.join('; ') + ' — wait for those to clear or fund the wallet.';
+}
+
+function signalError(signal: AbortSignal): Error {
+  const reason = (signal as { reason?: unknown }).reason;
+  if (reason instanceof Error) return reason;
+  const e = new Error('This operation was aborted');
+  e.name = 'AbortError';
+  return e;
+}
+
+/**
+ * Errors whose cause proves the request never reached the network: the
+ * payment cannot have settled, so the reservation should release normally.
+ * Anything else after dispatch (abort, timeout, reset, unknown) errs tight.
+ */
+const NOT_SENT_CODES = new Set(['ECONNREFUSED', 'ENOTFOUND', 'EAI_AGAIN', 'ENETUNREACH', 'EHOSTUNREACH', 'ERR_INVALID_URL']);
+function definitelyNotSent(err: unknown): boolean {
+  const cause = (err as { cause?: { code?: unknown } } | null)?.cause;
+  const code = typeof cause?.code === 'string' ? cause.code : '';
+  return NOT_SENT_CODES.has(code);
+}
 
 function modalEndpoint(path: string): string {
   const chain = loadChain();
@@ -407,7 +465,7 @@ export const modalCreateCapability: CapabilityHandler = {
         return {
           output:
             `Insufficient USDC for ModalCreate (${tier}, ~${fmtUsd(price)}). ` +
-            `Other in-flight paid calls may be holding your balance — wait or fund the wallet.`,
+            describeHeadroom(),
           isError: true,
         };
       }

--- a/src/tools/modal.ts
+++ b/src/tools/modal.ts
@@ -174,6 +174,13 @@ async function extractPaymentReq(response: Response): Promise<string | null> {
  * first POST gets a 402 with payment requirements; we sign and retry once
  * with the X-PAYMENT header. Returns the parsed JSON body and the raw
  * Response (callers may need status code).
+ *
+ * `reservation` is the caller's wallet hold for this call. If the signed
+ * (paid) request has been dispatched and the call then aborts or times out
+ * before a response, the outcome is ambiguous — the gateway may already have
+ * settled the payment. The hold is marked ambiguous so the reservation layer
+ * keeps counting it (see reservation.ts) instead of the caller's `finally`
+ * releasing it as if nothing was spent.
  */
 async function postWithPayment(
   endpoint: string,
@@ -181,6 +188,7 @@ async function postWithPayment(
   resourceDescription: string,
   abortSignal: AbortSignal,
   timeoutMs: number,
+  reservation?: ReservationToken | null,
 ): Promise<{ ok: boolean; status: number; body: Record<string, unknown>; raw: string }> {
   const chain = loadChain();
   const headers: Record<string, string> = {
@@ -191,6 +199,7 @@ async function postWithPayment(
   const onParentAbort = () => ctrl.abort();
   abortSignal.addEventListener('abort', onParentAbort, { once: true });
   const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  let paymentDispatched = false;
 
   try {
     const payload = JSON.stringify(body);
@@ -201,6 +210,7 @@ async function postWithPayment(
       if (!paymentHeaders) {
         return { ok: false, status: 402, body: { error: 'payment signing failed' }, raw: '' };
       }
+      paymentDispatched = true;
       response = await fetch(endpoint, {
         method: 'POST',
         signal: ctrl.signal,
@@ -213,6 +223,17 @@ async function postWithPayment(
     let parsed: Record<string, unknown> = {};
     try { parsed = raw ? JSON.parse(raw) : {}; } catch { /* leave as {} */ }
     return { ok: response.ok, status: response.status, body: parsed, raw };
+  } catch (err) {
+    if (paymentDispatched && reservation) {
+      // Signed request went out; abort/timeout hit before we saw the result.
+      // Money may be gone — keep the hold counted rather than releasing it.
+      walletReservation.markAmbiguous(reservation);
+      logger.warn(
+        `[franklin] Modal payment outcome ambiguous (${(err as Error).message}); ` +
+        `holding ${reservation.amountUsd.toFixed(4)} USDC reservation until balance refresh`,
+      );
+    }
+    throw err;
   } finally {
     clearTimeout(timer);
     abortSignal.removeEventListener('abort', onParentAbort);
@@ -406,6 +427,7 @@ export const modalCreateCapability: CapabilityHandler = {
         'Franklin Modal sandbox create',
         ctx.abortSignal,
         90_000, // 90s — sandbox cold-start can be slow on fresh GPU pulls
+        reservation,
       );
       const latencyMs = Date.now() - callStartedAt;
 
@@ -555,6 +577,7 @@ export const modalExecCapability: CapabilityHandler = {
         'Franklin Modal sandbox exec',
         ctx.abortSignal,
         Math.max(30_000, ((coercedTimeout ?? 300) + 30) * 1000),
+        reservation,
       );
       const latencyMs = Date.now() - callStartedAt;
 
@@ -643,6 +666,7 @@ export const modalStatusCapability: CapabilityHandler = {
         'Franklin Modal sandbox status',
         ctx.abortSignal,
         30_000,
+        reservation,
       );
       const latencyMs = Date.now() - callStartedAt;
 
@@ -697,6 +721,7 @@ export const modalTerminateCapability: CapabilityHandler = {
         'Franklin Modal sandbox terminate',
         ctx.abortSignal,
         30_000,
+        reservation,
       );
       const latencyMs = Date.now() - callStartedAt;
 

--- a/src/wallet/reservation.ts
+++ b/src/wallet/reservation.ts
@@ -14,6 +14,13 @@
  *   1. Tool calls hold(amount) before paying.
  *   2. hold() refuses if (balance - sum(active reservations)) < amount.
  *   3. After payment succeeds OR fails, tool calls release(token).
+ *   4. If the outcome is AMBIGUOUS — the signed request was dispatched and
+ *      then aborted / timed out before a response came back — the caller
+ *      marks the token ambiguous instead. The gateway may have settled the
+ *      payment on-chain, so the amount stays counted against headroom for
+ *      a grace window and is dropped on the next fresh balance fetch after
+ *      that window (which reflects the real on-chain state). The cap can
+ *      only err tight, never loose.
  *
  * Single-process JS guarantees the check-and-set is atomic (no real race),
  * and balance is cached briefly so we don't hit the RPC for every hold.
@@ -28,11 +35,28 @@ export interface ReservationToken {
 }
 
 const BALANCE_CACHE_MS = 5_000;
+/**
+ * How long an ambiguous-settlement hold stays counted before a fresh
+ * balance fetch is trusted to reflect it. x402 settlement on Base / Solana
+ * lands well inside this; the window only bounds how long we err tight.
+ */
+export const AMBIGUOUS_GRACE_MS = 30_000;
+
+async function readChainBalance(): Promise<number> {
+  if (loadChain() === 'solana') {
+    const client = await setupAgentSolanaWallet({ silent: true });
+    return client.getBalance();
+  }
+  const client = setupAgentWallet({ silent: true });
+  return client.getBalance();
+}
 
 class WalletReservationManager {
   private reserved = new Map<string, number>();
+  private ambiguous = new Map<string, { amountUsd: number; at: number }>();
   private cachedBalance: { value: number; fetchedAt: number } | null = null;
   private balanceFetchInflight: Promise<number> | null = null;
+  private balanceFetcher: () => Promise<number> = readChainBalance;
 
   private async fetchBalance(): Promise<number> {
     if (this.cachedBalance && Date.now() - this.cachedBalance.fetchedAt < BALANCE_CACHE_MS) {
@@ -40,15 +64,9 @@ class WalletReservationManager {
     }
     if (this.balanceFetchInflight) return this.balanceFetchInflight;
 
-    const chain = loadChain();
     this.balanceFetchInflight = (async () => {
       try {
-        if (chain === 'solana') {
-          const client = await setupAgentSolanaWallet({ silent: true });
-          return await client.getBalance();
-        }
-        const client = setupAgentWallet({ silent: true });
-        return await client.getBalance();
+        return await this.balanceFetcher();
       } catch {
         // If balance fetch fails, return Infinity so reservations don't
         // block — the actual payment will surface the real error. We'd
@@ -57,8 +75,15 @@ class WalletReservationManager {
       }
     })()
       .then((v) => {
-        this.cachedBalance = { value: v, fetchedAt: Date.now() };
+        const now = Date.now();
+        this.cachedBalance = { value: v, fetchedAt: now };
         this.balanceFetchInflight = null;
+        // A fresh on-chain read already includes any ambiguous spend that
+        // actually settled; drop entries past the grace window so a
+        // genuinely-absent spend self-heals instead of pinning headroom.
+        for (const [id, entry] of this.ambiguous) {
+          if (now - entry.at >= AMBIGUOUS_GRACE_MS) this.ambiguous.delete(id);
+        }
         return v;
       });
 
@@ -68,6 +93,7 @@ class WalletReservationManager {
   private totalReserved(): number {
     let sum = 0;
     for (const v of this.reserved.values()) sum += v;
+    for (const e of this.ambiguous.values()) sum += e.amountUsd;
     return sum;
   }
 
@@ -104,14 +130,56 @@ class WalletReservationManager {
     }
   }
 
+  /**
+   * Mark a hold as ambiguous: the signed payment was dispatched but the
+   * request aborted / timed out before we saw the outcome. The money may be
+   * gone, so keep the amount counted against headroom (see header). A later
+   * release() of the same token is a no-op — the ambiguous entry outlives it.
+   */
+  markAmbiguous(token: ReservationToken | string | null | undefined): void {
+    if (!token) return;
+    const id = typeof token === 'string' ? token : token.id;
+    const amountUsd = this.reserved.get(id);
+    if (amountUsd === undefined || amountUsd <= 0) return;
+    this.reserved.delete(id);
+    this.ambiguous.set(id, { amountUsd, at: Date.now() });
+    this.cachedBalance = null;
+  }
+
   /** Force the next hold() to refetch balance from chain. */
   invalidateBalance(): void {
     this.cachedBalance = null;
   }
 
   /** Snapshot of current reservation state — diagnostic / testing only. */
-  snapshot(): { count: number; totalUsd: number } {
-    return { count: this.reserved.size, totalUsd: this.totalReserved() };
+  snapshot(): { count: number; totalUsd: number; ambiguousCount: number; ambiguousUsd: number } {
+    let ambiguousUsd = 0;
+    for (const e of this.ambiguous.values()) ambiguousUsd += e.amountUsd;
+    return {
+      count: this.reserved.size,
+      totalUsd: this.totalReserved(),
+      ambiguousCount: this.ambiguous.size,
+      ambiguousUsd,
+    };
+  }
+
+  /** Testing only — reset all bookkeeping and cached balance. */
+  _resetForTests(fetcher?: () => Promise<number>): void {
+    this.reserved.clear();
+    this.ambiguous.clear();
+    this.cachedBalance = null;
+    this.balanceFetchInflight = null;
+    this.balanceFetcher = fetcher ?? readChainBalance;
+  }
+
+  /** Testing only — seed the balance cache so hold() never touches RPC. */
+  _seedBalanceForTests(value: number): void {
+    this.cachedBalance = { value, fetchedAt: Date.now() };
+  }
+
+  /** Testing only — backdate an ambiguous entry past the grace window. */
+  _ageAmbiguousForTests(ms: number): void {
+    for (const e of this.ambiguous.values()) e.at -= ms;
   }
 }
 

--- a/src/wallet/reservation.ts
+++ b/src/wallet/reservation.ts
@@ -1,9 +1,9 @@
 /**
  * WalletReservation — local accounting layer for concurrent paid tool calls.
  *
- * Problem this solves: when N batch tools (ImageGen / VideoGen) run in
- * parallel, each independently checks balance and dispatches its x402
- * payment. With balance $0.20 and 6 calls × $0.04 each, all 6 see "$0.20
+ * Problem this solves: when N paid tool calls (today: the Modal sandbox
+ * tools) run in parallel, each independently checks balance and dispatches
+ * its x402 payment. With balance $0.20 and 6 calls × $0.04 each, all 6 see "$0.20
  * available, $0.04 fits" and start; only 5 can actually settle on-chain,
  * the rest fail mid-flight with insufficient-funds and the user sees
  * partial completion with no preflight warning.
@@ -18,8 +18,11 @@
  *      then aborted / timed out before a response came back — the caller
  *      marks the token ambiguous instead. The gateway may have settled the
  *      payment on-chain, so the amount stays counted against headroom for
- *      a grace window and is dropped on the next fresh balance fetch after
- *      that window (which reflects the real on-chain state). The cap can
+ *      a grace window and is dropped on the next fresh balance fetch that
+ *      STARTED after the window closed (so the read reflects the real
+ *      on-chain state). The window is sized by the caller from its own
+ *      request timeout: the gateway may still be running the paid work when
+ *      we abort, and settlement lands when that work finishes. The cap can
  *      only err tight, never loose.
  *
  * Single-process JS guarantees the check-and-set is atomic (no real race),
@@ -36,9 +39,11 @@ export interface ReservationToken {
 
 const BALANCE_CACHE_MS = 5_000;
 /**
- * How long an ambiguous-settlement hold stays counted before a fresh
- * balance fetch is trusted to reflect it. x402 settlement on Base / Solana
- * lands well inside this; the window only bounds how long we err tight.
+ * Settlement margin added on top of the caller-supplied request timeout for
+ * an ambiguous-settlement hold. The window starts at OUR abort, not at the
+ * gateway's settlement: if the gateway settles after the paid work finishes,
+ * that can be up to the request timeout later, plus on-chain confirmation.
+ * Callers pass `graceMs = timeoutMs + AMBIGUOUS_GRACE_MS`.
  */
 export const AMBIGUOUS_GRACE_MS = 30_000;
 
@@ -53,7 +58,7 @@ async function readChainBalance(): Promise<number> {
 
 class WalletReservationManager {
   private reserved = new Map<string, number>();
-  private ambiguous = new Map<string, { amountUsd: number; at: number }>();
+  private ambiguous = new Map<string, { amountUsd: number; expiresAt: number }>();
   private cachedBalance: { value: number; fetchedAt: number } | null = null;
   private balanceFetchInflight: Promise<number> | null = null;
   private balanceFetcher: () => Promise<number> = readChainBalance;
@@ -64,9 +69,21 @@ class WalletReservationManager {
     }
     if (this.balanceFetchInflight) return this.balanceFetchInflight;
 
+    // Sample the clock BEFORE the read goes out: a read that started inside
+    // an ambiguous entry's window cannot be trusted to reflect it, however
+    // long the RPC took to answer.
+    const startedAt = Date.now();
     this.balanceFetchInflight = (async () => {
       try {
-        return await this.balanceFetcher();
+        const v = await this.balanceFetcher();
+        // A real on-chain read already includes any ambiguous spend that
+        // settled; drop entries whose window closed before this read began
+        // so a genuinely-absent spend self-heals instead of pinning headroom.
+        // Only on a real read: the Infinity fallback below reflects nothing.
+        for (const [id, entry] of this.ambiguous) {
+          if (entry.expiresAt <= startedAt) this.ambiguous.delete(id);
+        }
+        return v;
       } catch {
         // If balance fetch fails, return Infinity so reservations don't
         // block — the actual payment will surface the real error. We'd
@@ -75,15 +92,8 @@ class WalletReservationManager {
       }
     })()
       .then((v) => {
-        const now = Date.now();
-        this.cachedBalance = { value: v, fetchedAt: now };
+        this.cachedBalance = { value: v, fetchedAt: Date.now() };
         this.balanceFetchInflight = null;
-        // A fresh on-chain read already includes any ambiguous spend that
-        // actually settled; drop entries past the grace window so a
-        // genuinely-absent spend self-heals instead of pinning headroom.
-        for (const [id, entry] of this.ambiguous) {
-          if (now - entry.at >= AMBIGUOUS_GRACE_MS) this.ambiguous.delete(id);
-        }
         return v;
       });
 
@@ -133,16 +143,18 @@ class WalletReservationManager {
   /**
    * Mark a hold as ambiguous: the signed payment was dispatched but the
    * request aborted / timed out before we saw the outcome. The money may be
-   * gone, so keep the amount counted against headroom (see header). A later
-   * release() of the same token is a no-op — the ambiguous entry outlives it.
+   * gone, so keep the amount counted against headroom (see header) for
+   * `graceMs` (default AMBIGUOUS_GRACE_MS; callers add their request
+   * timeout). A later release() of the same token is a no-op — the ambiguous
+   * entry outlives it. Idempotent: a second call for the same id is a no-op.
    */
-  markAmbiguous(token: ReservationToken | string | null | undefined): void {
+  markAmbiguous(token: ReservationToken | string | null | undefined, graceMs = AMBIGUOUS_GRACE_MS): void {
     if (!token) return;
     const id = typeof token === 'string' ? token : token.id;
     const amountUsd = this.reserved.get(id);
     if (amountUsd === undefined || amountUsd <= 0) return;
     this.reserved.delete(id);
-    this.ambiguous.set(id, { amountUsd, at: Date.now() });
+    this.ambiguous.set(id, { amountUsd, expiresAt: Date.now() + Math.max(0, graceMs) });
     this.cachedBalance = null;
   }
 
@@ -177,9 +189,9 @@ class WalletReservationManager {
     this.cachedBalance = { value, fetchedAt: Date.now() };
   }
 
-  /** Testing only — backdate an ambiguous entry past the grace window. */
+  /** Testing only — shift every ambiguous entry's expiry earlier by `ms`. */
   _ageAmbiguousForTests(ms: number): void {
-    for (const e of this.ambiguous.values()) e.at -= ms;
+    for (const e of this.ambiguous.values()) e.expiresAt -= ms;
   }
 }
 

--- a/test/reservation.local.mjs
+++ b/test/reservation.local.mjs
@@ -1,0 +1,56 @@
+/**
+ * WalletReservation accounting — ambiguous-settlement path (#128).
+ * No network: balance is seeded so hold() never hits RPC.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const { walletReservation, AMBIGUOUS_GRACE_MS } = await import('../dist/wallet/reservation.js');
+
+test('markAmbiguous keeps the amount counted and survives a later release()', async () => {
+  walletReservation._resetForTests();
+  walletReservation._seedBalanceForTests(0.10);
+
+  const a = await walletReservation.hold(0.06);
+  assert.ok(a, 'first hold fits');
+  assert.equal(await walletReservation.hold(0.06), null, 'second hold blocked by first');
+
+  // Paid request dispatched, then aborted: outcome ambiguous.
+  walletReservation.markAmbiguous(a);
+  // Caller's finally still runs release() — must be a no-op now.
+  walletReservation.release(a);
+  walletReservation._seedBalanceForTests(0.10); // on-chain read still shows old balance
+
+  const snap = walletReservation.snapshot();
+  assert.equal(snap.count, 0);
+  assert.equal(snap.ambiguousCount, 1);
+  assert.equal(snap.totalUsd, 0.06, 'ambiguous spend still counted against headroom');
+  assert.equal(await walletReservation.hold(0.06), null, 'cap errs tight, not loose');
+});
+
+test('ambiguous holds self-heal after the grace window on a fresh balance fetch', async () => {
+  let fetches = 0;
+  walletReservation._resetForTests(async () => { fetches++; return 0.10; });
+  const a = await walletReservation.hold(0.06);
+  walletReservation.markAmbiguous(a);
+
+  // Inside the window a fresh on-chain read does NOT prune the entry.
+  assert.equal(await walletReservation.hold(0.06), null);
+  assert.ok(fetches >= 2, 'markAmbiguous invalidated the cache, forcing a refetch');
+
+  // Past the window, the next fresh fetch prunes it.
+  walletReservation._ageAmbiguousForTests(AMBIGUOUS_GRACE_MS + 1);
+  walletReservation.invalidateBalance();
+  const b = await walletReservation.hold(0.06);
+  assert.ok(b, 'hold succeeds once the ambiguous entry is pruned');
+  assert.equal(walletReservation.snapshot().ambiguousCount, 0);
+  walletReservation.release(b);
+});
+
+test('markAmbiguous is a no-op for free tokens and unknown ids', () => {
+  walletReservation._resetForTests();
+  walletReservation.markAmbiguous({ id: 'free-x', amountUsd: 0 });
+  walletReservation.markAmbiguous('res-does-not-exist');
+  walletReservation.markAmbiguous(null);
+  assert.equal(walletReservation.snapshot().ambiguousCount, 0);
+});

--- a/test/reservation.local.mjs
+++ b/test/reservation.local.mjs
@@ -1,25 +1,25 @@
 /**
  * WalletReservation accounting — ambiguous-settlement path (#128).
- * No network: balance is seeded so hold() never hits RPC.
+ * No network: every test injects a balance fetcher, and the postWithPayment
+ * tests stub global fetch + the x402 signer.
  */
-import { test } from 'node:test';
+import { test, after } from 'node:test';
 import assert from 'node:assert/strict';
 
 const { walletReservation, AMBIGUOUS_GRACE_MS } = await import('../dist/wallet/reservation.js');
+const { postWithPayment, _setPaymentSignerForTests } = await import('../dist/tools/modal.js');
+
+const fixed = (v) => async () => v;
 
 test('markAmbiguous keeps the amount counted and survives a later release()', async () => {
-  walletReservation._resetForTests();
-  walletReservation._seedBalanceForTests(0.10);
+  walletReservation._resetForTests(fixed(0.10));
 
   const a = await walletReservation.hold(0.06);
   assert.ok(a, 'first hold fits');
   assert.equal(await walletReservation.hold(0.06), null, 'second hold blocked by first');
 
-  // Paid request dispatched, then aborted: outcome ambiguous.
-  walletReservation.markAmbiguous(a);
-  // Caller's finally still runs release() — must be a no-op now.
-  walletReservation.release(a);
-  walletReservation._seedBalanceForTests(0.10); // on-chain read still shows old balance
+  walletReservation.markAmbiguous(a, 1_000);
+  walletReservation.release(a); // caller's finally — must be a no-op now
 
   const snap = walletReservation.snapshot();
   assert.equal(snap.count, 0);
@@ -28,18 +28,41 @@ test('markAmbiguous keeps the amount counted and survives a later release()', as
   assert.equal(await walletReservation.hold(0.06), null, 'cap errs tight, not loose');
 });
 
-test('ambiguous holds self-heal after the grace window on a fresh balance fetch', async () => {
+test('markAmbiguous is idempotent and release-then-mark does not resurrect a hold', async () => {
+  walletReservation._resetForTests(fixed(0.10));
+  const a = await walletReservation.hold(0.06);
+  walletReservation.markAmbiguous(a, 1_000);
+  walletReservation.markAmbiguous(a, 1_000);
+  assert.equal(walletReservation.snapshot().ambiguousCount, 1, 'second mark is a no-op');
+
+  const b = await walletReservation.hold(0.03);
+  walletReservation.release(b);
+  walletReservation.markAmbiguous(b, 1_000);
+  assert.equal(walletReservation.snapshot().ambiguousCount, 1, 'released token cannot become ambiguous');
+  assert.equal(walletReservation.snapshot().totalUsd, 0.06);
+});
+
+test('ambiguous holds self-heal only on a real balance read that started after the window', async () => {
   let fetches = 0;
   walletReservation._resetForTests(async () => { fetches++; return 0.10; });
   const a = await walletReservation.hold(0.06);
-  walletReservation.markAmbiguous(a);
+  assert.equal(fetches, 1);
+  walletReservation.markAmbiguous(a, 5_000);
 
-  // Inside the window a fresh on-chain read does NOT prune the entry.
+  // markAmbiguous invalidated the cache: the next hold refetches, but the
+  // window is still open so the entry survives the read.
   assert.equal(await walletReservation.hold(0.06), null);
-  assert.ok(fetches >= 2, 'markAmbiguous invalidated the cache, forcing a refetch');
+  assert.equal(fetches, 2, 'markAmbiguous forced a refetch');
+  assert.equal(walletReservation.snapshot().ambiguousCount, 1, 'inside the window: kept');
 
-  // Past the window, the next fresh fetch prunes it.
-  walletReservation._ageAmbiguousForTests(AMBIGUOUS_GRACE_MS + 1);
+  // Just short of the window: still kept.
+  walletReservation._ageAmbiguousForTests(4_999);
+  walletReservation.invalidateBalance();
+  assert.equal(await walletReservation.hold(0.06), null);
+  assert.equal(walletReservation.snapshot().ambiguousCount, 1, 'boundary: kept until expiresAt <= read start');
+
+  // Past the window: the next real read prunes it.
+  walletReservation._ageAmbiguousForTests(2);
   walletReservation.invalidateBalance();
   const b = await walletReservation.hold(0.06);
   assert.ok(b, 'hold succeeds once the ambiguous entry is pruned');
@@ -47,10 +70,144 @@ test('ambiguous holds self-heal after the grace window on a fresh balance fetch'
   walletReservation.release(b);
 });
 
+test('a failed balance read (Infinity fallback) never prunes ambiguous entries', async () => {
+  walletReservation._resetForTests(fixed(0.10));
+  const a = await walletReservation.hold(0.06);
+  walletReservation.markAmbiguous(a, 0); // window already closed
+
+  walletReservation._resetForTests(async () => { throw new Error('rpc down'); });
+  // _resetForTests cleared state; re-create the expired ambiguous entry.
+  walletReservation._seedBalanceForTests(0.10);
+  const b = await walletReservation.hold(0.06);
+  walletReservation.markAmbiguous(b, 0);
+  walletReservation.invalidateBalance();
+
+  const c = await walletReservation.hold(0.06); // fetch throws -> Infinity -> hold allowed
+  assert.ok(c, 'Infinity fallback does not block');
+  assert.equal(walletReservation.snapshot().ambiguousCount, 1, 'but it must not prune on a read that reflects nothing');
+  walletReservation.release(c);
+});
+
+test('a read that STARTED inside the window does not prune even if it resolves after', async () => {
+  let release;
+  const gate = new Promise((r) => { release = r; });
+  walletReservation._resetForTests(async () => { await gate; return 0.10; });
+  walletReservation._seedBalanceForTests(0.10);
+  const a = await walletReservation.hold(0.06);
+  walletReservation.markAmbiguous(a, 50);
+  const pending = walletReservation.hold(0.06); // read starts now, inside window
+  await new Promise((r) => setTimeout(r, 80)); // window closes while read is in flight
+  release();
+  assert.equal(await pending, null);
+  assert.equal(walletReservation.snapshot().ambiguousCount, 1, 'F5: clock sampled at read start');
+});
+
 test('markAmbiguous is a no-op for free tokens and unknown ids', () => {
-  walletReservation._resetForTests();
+  walletReservation._resetForTests(fixed(1));
   walletReservation.markAmbiguous({ id: 'free-x', amountUsd: 0 });
   walletReservation.markAmbiguous('res-does-not-exist');
   walletReservation.markAmbiguous(null);
   assert.equal(walletReservation.snapshot().ambiguousCount, 0);
+});
+
+// ─── postWithPayment: which failures are ambiguous ────────────────────────
+
+const realFetch = globalThis.fetch;
+after(() => { globalThis.fetch = realFetch; _setPaymentSignerForTests(null); });
+
+function res402() {
+  return new Response(JSON.stringify({ accepts: [] }), { status: 402, headers: { 'content-type': 'application/json' } });
+}
+/** fetch stub: first call 402, second call runs `paid(signal)`. */
+function stubFetch(paid) {
+  let n = 0;
+  globalThis.fetch = async (_url, init) => {
+    n++;
+    if (n === 1) return res402();
+    return paid(init.signal);
+  };
+}
+const hangUntilAbort = (signal) => new Promise((_, reject) => {
+  signal.addEventListener('abort', () => {
+    const e = new Error('This operation was aborted'); e.name = 'AbortError'; reject(e);
+  }, { once: true });
+});
+
+async function runPaid({ paid, timeoutMs = 60, signer, parent = new AbortController() }) {
+  walletReservation._resetForTests(fixed(1));
+  _setPaymentSignerForTests(signer ?? (async () => ({ 'PAYMENT-SIGNATURE': 'sig' })));
+  stubFetch(paid);
+  const token = await walletReservation.hold(0.25);
+  let threw = null;
+  try {
+    await postWithPayment('https://gateway.invalid/modal/create', {}, 'test', parent.signal, timeoutMs, token);
+  } catch (e) { threw = e; }
+  walletReservation.release(token); // the caller's finally
+  return { threw, snap: walletReservation.snapshot(), token };
+}
+
+test('timeout after the signed request is dispatched -> ambiguous, hold kept', async () => {
+  const { threw, snap } = await runPaid({ paid: hangUntilAbort, timeoutMs: 30 });
+  assert.ok(threw, 'postWithPayment still throws');
+  assert.equal(snap.ambiguousCount, 1);
+  assert.equal(snap.ambiguousUsd, 0.25);
+  assert.equal(snap.count, 0, 'moved out of the live reservation set');
+});
+
+test('ambiguous window is sized by the call timeout + margin', async () => {
+  const { token } = await runPaid({ paid: hangUntilAbort, timeoutMs: 30 });
+  // Age by the base margin: still inside (window = 30ms + AMBIGUOUS_GRACE_MS).
+  walletReservation._ageAmbiguousForTests(AMBIGUOUS_GRACE_MS - 5);
+  walletReservation.invalidateBalance();
+  assert.equal(await walletReservation.hold(0.9), null, 'still counted');
+  walletReservation._ageAmbiguousForTests(100);
+  walletReservation.invalidateBalance();
+  assert.ok(await walletReservation.hold(0.9), 'pruned after timeout + margin');
+  void token;
+});
+
+test('signal already aborted before dispatch -> NOT ambiguous (F2)', async () => {
+  const parent = new AbortController();
+  const signer = async () => { parent.abort(); return { 'PAYMENT-SIGNATURE': 'sig' }; };
+  let paidCalled = false;
+  const { threw, snap } = await runPaid({ paid: () => { paidCalled = true; return hangUntilAbort(new AbortController().signal); }, signer, parent });
+  assert.ok(threw);
+  assert.equal(paidCalled, false, 'paid request never dispatched');
+  assert.equal(snap.ambiguousCount, 0);
+  assert.equal(snap.totalUsd, 0, 'released normally');
+});
+
+test('connection refused on the paid request -> NOT ambiguous (F2)', async () => {
+  const paid = async () => { const e = new TypeError('fetch failed'); e.cause = { code: 'ECONNREFUSED' }; throw e; };
+  const { threw, snap } = await runPaid({ paid });
+  assert.ok(threw);
+  assert.equal(snap.ambiguousCount, 0);
+  assert.equal(snap.totalUsd, 0);
+});
+
+test('paid 200 whose body is cut off -> throws and is ambiguous, not ok:true (F3)', async () => {
+  const paid = async () => ({
+    ok: true, status: 200,
+    text: async () => { const e = new Error('aborted'); e.name = 'AbortError'; throw e; },
+  });
+  const { threw, snap } = await runPaid({ paid });
+  assert.ok(threw, 'must not return { ok: true, body: {} }');
+  assert.equal(snap.ambiguousCount, 1);
+});
+
+test('probe (unpaid) request failing -> nothing dispatched, nothing ambiguous', async () => {
+  walletReservation._resetForTests(fixed(1));
+  globalThis.fetch = async () => { const e = new Error('aborted'); e.name = 'AbortError'; throw e; };
+  const token = await walletReservation.hold(0.25);
+  await assert.rejects(() => postWithPayment('https://gateway.invalid/x', {}, 't', new AbortController().signal, 50, token));
+  walletReservation.release(token);
+  assert.equal(walletReservation.snapshot().totalUsd, 0);
+});
+
+test('paid request succeeds -> normal release, no ambiguity', async () => {
+  const paid = async () => new Response(JSON.stringify({ sandbox_id: 'sb_1' }), { status: 200 });
+  const { threw, snap } = await runPaid({ paid });
+  assert.equal(threw, null);
+  assert.equal(snap.ambiguousCount, 0);
+  assert.equal(snap.totalUsd, 0);
 });


### PR DESCRIPTION
## Summary
- `postWithPayment` tracks whether the signed (paid) request was dispatched; if the call then aborts / times out, the wallet hold is marked **ambiguous** instead of being released by the caller's `finally`.
- `WalletReservation` keeps ambiguous amounts counted against headroom for a 30s grace window and prunes them on the next fresh on-chain balance read after that window (which already reflects a real settlement). Cap errs tight, never loose; a genuinely-absent spend self-heals.
- Balance fetcher is injectable for tests; new `test/reservation.local.mjs` (3 tests) wired into `npm test`.

Closes #128

## Test plan
- [x] `npm test` — 673/673 pass