### PR TITLE
fix(proxy): a vision request could fall back onto a text-only paid model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## Franklin Agent 3.43.1 — a guard that only runs on the happy path is not a guard
+
+**A vision request could fall back onto a model that cannot read images, and
+pay for it.** The proxy's pre-request vision guard swaps a text-only pick for
+a vision sibling, but it runs once, before the call. The fallback chain is
+walked *after* a failure and was not vision-aware, so an image sent to
+`claude-sonnet-4.6` that hit a 429 fell straight onto
+`deepseek/deepseek-chat`, which cannot read images at all.
+
+```
+before  [claude-sonnet-4.6, deepseek-chat, gemini-2.5-flash, nano-omni]
+after   [claude-sonnet-4.6, gemini-2.5-flash]
+```
+
+**Why that costs money.** The gateway does not reliably refuse those calls
+before payment. Probing both gateways with an *unpaid* request separates the
+two cases for free — a 400 means refused pre-payment, a 402 means it is
+quoting you for a call the upstream will reject:
+
+| model | Base | Solana |
+|---|---|---|
+| `zai/glm-5.3`, `glm-5.1`, `glm-5-turbo` | 402 — quotes you | 400 refused |
+| `deepseek/deepseek-chat` | 402 — quotes you | 400 refused |
+| `zai/glm-5.3-flash` (natively multimodal) | 402 correct | 402 correct |
+
+On Base the retry is quoted, signed, settled, and only then rejected upstream
+— or answered without the image, which is worse. Franklin no longer depends
+on either gateway getting that right.
+
+This is the same shape as the free-tier guard added in 3.43.0: the chain has
+to know what the request *needs*, not just what it costs. The two filters now
+compose, so a free vision request gets rungs that are both free and
+vision-capable. The requirement is re-derived from the raw body at the
+fallback site rather than reused from the pre-request guard, whose binding is
+out of scope by then — losing it silently on the retry path is the bug, so
+the fix does not depend on a binding that can go out of scope again.
+
+Found while chasing a gateway-side report, which is the third instance this
+week of a mechanism that existed and was simply routed around by the composed
+path. The others were an approval gate disarmed by an unreachable branch and
+a kill-switch the free profile never consulted.
+
 ## Franklin Agent 3.43.0 — the free tier stops naming ghosts
 
 **Every free model Franklin asked for had left the catalog.** On 2026-08-30

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockrun/franklin",
-  "version": "3.43.0",
+  "version": "3.43.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockrun/franklin",
-      "version": "3.43.0",
+      "version": "3.43.1",
       "license": "Apache-2.0",
       "workspaces": [
         "apps/desktop"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockrun/franklin",
-  "version": "3.43.0",
+  "version": "3.43.1",
   "description": "Franklin Agent \u2014 The AI agent with a wallet. Spends USDC autonomously to get real work done. Pay per action, no subscriptions.",
   "type": "module",
   "exports": {

--- a/src/proxy/fallback.ts
+++ b/src/proxy/fallback.ts
@@ -5,6 +5,7 @@
 
 import { logger } from '../logger.js';
 import { FREE_DEFAULT_MODEL, isFreeModelId } from '../free-models.js';
+import { isVisionModel } from '../router/vision.js';
 
 export interface FallbackConfig {
   /** Models to try in order of priority */
@@ -174,10 +175,30 @@ export const ROUTING_PROFILES = new Set([
  */
 export function buildFallbackChain(
   startModel: string,
-  config: FallbackConfig = DEFAULT_FALLBACK_CONFIG
+  config: FallbackConfig = DEFAULT_FALLBACK_CONFIG,
+  needsVision = false,
 ): string[] {
   // Never include routing profiles in the chain — they'd cause 400s
-  const safeChain = config.chain.filter(m => !ROUTING_PROFILES.has(m));
+  let safeChain = config.chain.filter(m => !ROUTING_PROFILES.has(m));
+
+  // A request carrying images must not fall back onto a text-only model.
+  //
+  // The pre-request guard in proxy/server.ts swaps a text-only pick for a
+  // vision sibling, but it runs ONCE, before the call. This chain is walked
+  // AFTER a failure, so the guard was bypassed on every retry: an image sent
+  // to claude-sonnet-4.6 that hit a 429 fell straight to
+  // deepseek/deepseek-chat, which cannot read images at all.
+  //
+  // That costs real money. The gateway does not always refuse these before
+  // payment — probed 2026-08-31, Base returns 402 (a payment quote) for an
+  // image request to deepseek/deepseek-chat and the whole zai/glm-5.x line,
+  // while Solana correctly 400s them pre-payment. So on Base the retry is
+  // quoted, signed, settled, and THEN rejected upstream — or worse, answered
+  // without the image. Same shape as the free-tier guard above: the chain has
+  // to know what the request needs, not just what it costs.
+  if (needsVision) {
+    safeChain = safeChain.filter(m => isVisionModel(m));
+  }
 
   // Free start model → free-only chain. Ends the walk rather than reaching for
   // a paid rung; the caller gets the failure instead of a surprise charge.

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -235,6 +235,29 @@ function withinRateLimit(): boolean {
   return true;
 }
 
+/**
+ * Does this raw request body carry image content?
+ *
+ * The pre-request vision guard computes this from the already-parsed body, but
+ * that binding is out of scope by the time the FALLBACK chain is built — and
+ * the fallback walk is exactly where an unguarded retry drops an image onto a
+ * text-only model the gateway will still charge for. Re-derived from the raw
+ * body so the retry path cannot silently lose the requirement.
+ */
+function bodyNeedsVision(body: string | undefined): boolean {
+  if (!body) return false;
+  try {
+    const parsed = JSON.parse(body) as { messages?: unknown };
+    return messagesNeedVision(
+      (parsed.messages ?? []) as Array<{ role?: string; content?: unknown }>,
+    );
+  } catch {
+    // Unparseable body: assume no images rather than filtering the chain down
+    // on a guess. The pre-request guard already ran on the parsed copy.
+    return false;
+  }
+}
+
 export function createProxy(options: ProxyOptions): http.Server {
   // Wire stderr-mirroring of unified logger output to the proxy's debug
   // flag — same pattern as interactiveSession in agent/loop. File writes
@@ -548,7 +571,11 @@ export function createProxy(options: ProxyOptions): http.Server {
             chain: [
               ...new Set([
                 ...routerCandidates,
-                ...buildFallbackChain(requestModel),
+                // Recomputed here rather than reused from the pre-request
+                // guard above: that const is out of scope by this point, and
+                // without it the RETRY path drops images onto a text-only
+                // model that the gateway will happily charge for.
+                ...buildFallbackChain(requestModel, DEFAULT_FALLBACK_CONFIG, bodyNeedsVision(body)),
               ]),
             ],
           };

--- a/test/local.mjs
+++ b/test/local.mjs
@@ -6034,6 +6034,29 @@ test('free model catalog: picker, shortcuts, pricing, and weak-model guard stay 
   }
 });
 
+test('buildFallbackChain: a vision request never falls back to a text-only model', async () => {
+  const { buildFallbackChain, DEFAULT_FALLBACK_CONFIG } = await import('../dist/proxy/fallback.js');
+  const { isVisionModel } = await import('../dist/router/vision.js');
+
+  // The pre-request vision guard runs ONCE, before the call. The fallback
+  // chain is walked AFTER a failure, so an image sent to a vision model that
+  // 429'd used to land on deepseek/deepseek-chat, which cannot read images.
+  // The gateway does not always refuse that before payment — probed
+  // 2026-08-31, Base returns 402 (a payment quote) for an image request to
+  // deepseek/deepseek-chat and the whole zai/glm-5.x line, so the retry gets
+  // quoted, signed and settled before the upstream rejects it.
+  const vision = buildFallbackChain('anthropic/claude-sonnet-4.6', DEFAULT_FALLBACK_CONFIG, true);
+  for (const m of vision) {
+    assert.equal(isVisionModel(m), true, `vision request must not fall back to text-only ${m}`);
+  }
+  assert.ok(!vision.includes('deepseek/deepseek-chat'), 'deepseek/deepseek-chat is text-only');
+  assert.ok(vision.length > 1, 'the vision chain must still offer a real fallback rung');
+
+  // Text requests keep the full ladder — this filter is vision-only.
+  const text = buildFallbackChain('anthropic/claude-sonnet-4.6', DEFAULT_FALLBACK_CONFIG, false);
+  assert.ok(text.includes('deepseek/deepseek-chat'), 'a text request keeps the normal ladder');
+});
+
 test('buildFallbackChain: a free model never falls back to a paid one', async () => {
   const { buildFallbackChain } = await import('../dist/proxy/fallback.js');
   const { isFreeModelId, FREE_DEFAULT_MODEL } = await import('../dist/free-models.js');


### PR DESCRIPTION
## The bug

The pre-request vision guard in `proxy/server.ts` swaps a text-only pick for a vision sibling — but it runs **once, before the call**. The fallback chain is walked **after** a failure, and it was not vision-aware. So an image sent to a vision model that hit a 429 fell straight onto a model that cannot read images:

```
before  [claude-sonnet-4.6, deepseek-chat, gemini-2.5-flash, nano-omni]
after   [claude-sonnet-4.6, gemini-2.5-flash]
```

## Why it costs money

The gateway does not reliably refuse those calls before payment. Probed both gateways with an **unpaid** request — a `400` means refused pre-payment, a `402` means it is quoting you for a call the upstream will reject:

| model | Base | Solana |
|---|---|---|
| `zai/glm-5.3`, `glm-5.1`, `glm-5-turbo` | **402 — quotes you** | 400 refused pre-payment |
| `deepseek/deepseek-chat` | **402 — quotes you** | 400 refused pre-payment |
| `zai/glm-5.3-flash` (natively multimodal) | 402 ✅ correct | 402 ✅ correct |

On Base the retry is quoted, signed, settled — and only then rejected upstream, or answered without the image, which is worse. Solana gates it correctly; Base does not yet. Franklin should not depend on either gateway getting that right.

The Flash row is the control: it proves the Solana gate discriminates on actual capability rather than refusing everything.

## Shape

Same as the free-tier guard added to this function earlier today: **the chain has to know what the request needs, not just what it costs.** The two filters now compose — a free vision request gets free *and* vision-capable rungs.

The requirement is re-derived from the raw body at the fallback site rather than reused from the pre-request guard, whose binding is out of scope by then. Dropping it silently on the retry path is the bug being fixed, so the fix should not depend on a binding that can go out of scope again.

## Verification

- `npm test` green, plus a regression test asserting every rung of a vision chain is vision-capable and that text requests keep the full ladder
- Gateway behaviour above probed live on both chains, at zero cost (unpaid 400-vs-402 discrimination)

Credit to the `andy` session, whose `IMAGE_INPUT_UNSUPPORTED` work on the gateway side named the exact paid ids to test.
