### PR TITLE
fix(desktop): normalize release metadata

### DIFF
--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -85,14 +85,24 @@ jobs:
           merge-multiple: true
 
       - name: Generate checksums
-        run: sha256sum release/* > release/SHA256SUMS.txt
+        shell: bash
+        run: |
+          for file in release/*; do
+            normalized="${file// /.}"
+            if [[ "$file" != "$normalized" ]]; then mv "$file" "$normalized"; fi
+          done
+          sha256sum release/* | sed 's#  release/#  #' > release/SHA256SUMS.txt
+
+      - name: Prepare release metadata
+        id: release-meta
+        shell: bash
+        run: echo "name=Franklin Desktop ${GITHUB_REF_NAME#desktop-v}" >> "$GITHUB_OUTPUT"
 
       - name: Publish Desktop prerelease
         uses: softprops/action-gh-release@v2
         with:
-          name: Franklin Desktop ${{ github.ref_name }}
+          name: ${{ steps.release-meta.outputs.name }}
           prerelease: true
-          generate_release_notes: true
           body: |
             Franklin Desktop beta for macOS Apple Silicon and Windows x64.
 


### PR DESCRIPTION
## Summary

- normalize installer filenames before publishing so `SHA256SUMS.txt` matches downloaded asset names
- omit the staging `release/` path from checksum entries
- produce a clean Desktop release title without the duplicated `desktop-v` prefix
- stop auto-including unrelated main-repository changes in Desktop release notes

## Validation

- workflow YAML parsed successfully
- the current `desktop-v0.2.0-beta.1` Release checksum file was corrected and verified against GitHub asset digests