### PR TITLE
feat(desktop): reorganize sidebar navigation

### DIFF
--- a/apps/desktop/src/components/CloudWorkspacePanel.tsx
+++ b/apps/desktop/src/components/CloudWorkspacePanel.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Check, Cloud, FileText, FolderOpen, Laptop2, Loader2, MessageSquare, Plus, RefreshCw, Send, ShieldCheck, Users, X } from "lucide-react";
-import { useCloudWorkspace } from "../hooks/use-cloud-workspace";
+import type { CloudWorkspaceController } from "../hooks/use-cloud-workspace";
 import { MessageContent } from "./MessageContent";
-import { publishTeamWorkspaceNav, subscribeTeamWorkspaceRequest } from "../lib/team-workspace-events";
 import { CloudWorkspaceDrawer } from "./CloudWorkspaceDrawer";
 
 const friendlyCloudError = (message: string) => message.toLowerCase().includes("fetch failed")
@@ -13,8 +12,7 @@ function CloudRetryError({ message, className = "", onRetry }: { message: string
   return <div className={`cloud-error cloud-retry-error ${className}`.trim()}><span>{friendlyCloudError(message)}</span><button onClick={onRetry}><RefreshCw /> Retry</button></div>;
 }
 
-export function CloudWorkspacePanel() {
-  const cloud = useCloudWorkspace();
+export function CloudWorkspacePanel({ cloud }: { cloud: CloudWorkspaceController }) {
   const [workspaceName, setWorkspaceName] = useState("BlockRun Cloud Workspace");
   const [inviteInput, setInviteInput] = useState("");
   const [message, setMessage] = useState("");
@@ -29,12 +27,6 @@ export function CloudWorkspacePanel() {
   const scrollRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => { scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight }); }, [cloud.messages, cloud.sending]);
-  useEffect(() => publishTeamWorkspaceNav({
-    items: cloud.workspaces.map((workspace) => ({ id: workspace.id, name: workspace.name, role: workspace.role, memberCount: workspace.members.length, version: workspace.version })),
-    activeId: cloud.activeId,
-    loading: cloud.loading && !cloud.session,
-  }), [cloud.activeId, cloud.loading, cloud.session, cloud.workspaces]);
-  useEffect(() => subscribeTeamWorkspaceRequest(cloud.setActiveId), [cloud.setActiveId]);
 
   const openFile = async (path: string) => {
     setSelectedFile(path);

--- a/apps/desktop/src/components/FranklinChat.tsx
+++ b/apps/desktop/src/components/FranklinChat.tsx
@@ -30,7 +30,7 @@ import { useWallet } from "../hooks/use-wallet";
 import { useTryLang } from "../lib/i18n";
 import { prepareImageForUpload } from "../lib/image-compress";
 import { useStudioRegistry } from "../hooks/use-studio-registry";
-import { requestTeamWorkspace, subscribeTeamWorkspaceNav, type TeamWorkspaceNavState } from "../lib/team-workspace-events";
+import { useCloudWorkspace } from "../hooks/use-cloud-workspace";
 import { safeExternalHttpUrl } from "../lib/external-url";
 
 // Composer "focus" modes — force a specific live-data tool (server tool_choice).
@@ -86,8 +86,18 @@ export function FranklinChat() {
   const history = useChatHistory(auth.address, chatSpace);
   const usage = useSpend();
   const studio = useStudioRegistry();
-  const [teamNav, setTeamNav] = useState<TeamWorkspaceNavState>({ items: [], activeId: null, loading: true });
-  useEffect(() => subscribeTeamWorkspaceNav(setTeamNav), []);
+  const cloud = useCloudWorkspace();
+  const teamNav = {
+    items: cloud.workspaces.map((workspace) => ({
+      id: workspace.id,
+      name: workspace.name,
+      role: workspace.role,
+      memberCount: workspace.members.length,
+      version: workspace.version,
+    })),
+    activeId: cloud.activeId,
+    loading: cloud.loading && !cloud.session,
+  };
   const chat = useFranklinChat(history.messages, history.setMessages, history.ensureConvId);
   const { mode, setMode, model, setModel, models, selectedModel, status, activeTool, needsToolWallet, genConvId, mediaJobs, error, pendingPermission, respondToPermission, isBusy, isConnected, send, stop, stopMedia, regenerate, imageSize, setImageSize, imageSizes, videoRatio, setVideoRatio, videoRatios, videoResolution, setVideoResolution, videoResolutions } = chat;
   const genHere = genConvId === null || genConvId === history.activeId;
@@ -240,20 +250,28 @@ export function FranklinChat() {
   return (
     <div className="try-shell">
       <HistorySidebar
-        conversations={history.visibleConversations}
+        conversations={history.personalConversations}
         activeId={history.activeId}
-        onNew={() => {
-          if (chatSpace === "team") requestTeamWorkspace(null);
-          else history.newChat();
+        onNewChat={() => {
+          setChatSpace("personal");
+          history.newChatInSpace("personal");
+          setView("chat");
+          closeSidebarOnMobile();
+        }}
+        onNewProject={() => {
+          setChatSpace("team");
+          cloud.setActiveId(null);
           setView("chat");
           closeSidebarOnMobile();
         }}
         onSelect={(id) => {
-          history.selectChat(id);
+          setChatSpace("personal");
+          history.selectChatInSpace("personal", id);
           setView("chat");
           closeSidebarOnMobile();
         }}
         onDelete={history.deleteChat}
+        onTogglePinned={history.togglePinned}
         view={view}
         onView={(v) => {
           setView(v);
@@ -267,13 +285,13 @@ export function FranklinChat() {
         switchingWalletChain={switchingWalletChain}
         onSwitchWalletChain={switchWalletChain}
         chatSpace={chatSpace}
-        onChatSpace={setChatSpace}
         teamModeEnabled={studio.teamModeEnabled}
         teamWorkspaces={teamNav.items}
         activeTeamWorkspaceId={teamNav.activeId}
         teamLoading={teamNav.loading}
         onTeamWorkspace={(id) => {
-          requestTeamWorkspace(id);
+          setChatSpace("team");
+          cloud.setActiveId(id);
           setView("chat");
           closeSidebarOnMobile();
         }}
@@ -357,7 +375,7 @@ export function FranklinChat() {
         </div>
 
         {chatSpace === "team" && view === "chat" ? (
-          <CloudWorkspacePanel />
+          <CloudWorkspacePanel cloud={cloud} />
         ) : view === "agents" ? (
           <AgentsPanel
             agents={studio.agents}

--- a/apps/desktop/src/components/HistorySidebar.tsx
+++ b/apps/desktop/src/components/HistorySidebar.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import {
   Plus, MessageSquare, Trash2, Phone, Blocks, Images, Wallet, Sparkles, Search,
-  Grid2x2, ChevronRight, Terminal, Server, UserRound, Users, Bot, Cloud,
+  Grid2x2, ChevronRight, Terminal, Server, Bot, Folder, FolderPlus, Pin, PinOff,
 } from "lucide-react";
 import type { ChatSpace, Conversation } from "../hooks/use-chat-history";
 import type { WalletInfo } from "../lib/wire";
@@ -21,9 +21,11 @@ const PORTRAIT_URL = franklinAvatar;
 interface Props {
   conversations: Conversation[];
   activeId: string | null;
-  onNew: () => void;
+  onNewChat: () => void;
+  onNewProject: () => void;
   onSelect: (id: string) => void;
   onDelete: (id: string) => void;
+  onTogglePinned: (id: string) => void;
   view: TryView;
   onView: (v: TryView) => void;
   open: boolean;
@@ -35,7 +37,6 @@ interface Props {
   switchingWalletChain?: "base" | "solana" | null;
   onSwitchWalletChain?: (chain: "base" | "solana") => void | Promise<void>;
   chatSpace: ChatSpace;
-  onChatSpace: (space: ChatSpace) => void;
   teamModeEnabled?: boolean;
   teamWorkspaces?: TeamWorkspaceNavItem[];
   activeTeamWorkspaceId?: string | null;
@@ -43,7 +44,7 @@ interface Props {
   onTeamWorkspace?: (id: string) => void;
 }
 
-export function HistorySidebar({ conversations, activeId, onNew, onSelect, onDelete, view, onView, open, wallet, walletLoading, walletError, walletConnectionState, switchingWalletChain, onSwitchWalletChain, chatSpace, onChatSpace, teamModeEnabled = true, teamWorkspaces = [], activeTeamWorkspaceId = null, teamLoading = false, onTeamWorkspace }: Props) {
+export function HistorySidebar({ conversations, activeId, onNewChat, onNewProject, onSelect, onDelete, onTogglePinned, view, onView, open, wallet, walletLoading, walletError, walletConnectionState, switchingWalletChain, onSwitchWalletChain, chatSpace, teamModeEnabled = true, teamWorkspaces = [], activeTeamWorkspaceId = null, teamLoading = false, onTeamWorkspace }: Props) {
   const { t } = useTryLang();
   const { visibleItems } = useSidebarPreferences();
   const [searchOpen, setSearchOpen] = useState(false);
@@ -58,9 +59,10 @@ export function HistorySidebar({ conversations, activeId, onNew, onSelect, onDel
   };
 
   const sorted = [...conversations].sort((a, b) => b.updatedAt - a.updatedAt);
+  const pinned = sorted.filter((conversation) => conversation.pinnedAt).sort((a, b) => (b.pinnedAt ?? 0) - (a.pinnedAt ?? 0));
+  const recent = sorted.filter((conversation) => !conversation.pinnedAt);
 
   const navItems: { key: TryView; icon: React.ReactNode; label: string }[] = [
-    { key: "agents", icon: <Bot className="h-4 w-4" />, label: "Agents" },
     { key: "tools", icon: <Blocks className="h-4 w-4" />, label: t.marketplace },
     { key: "gallery", icon: <Images className="h-4 w-4" />, label: t.gallery },
     { key: "cli", icon: <Terminal className="h-4 w-4" />, label: t.cli },
@@ -85,104 +87,103 @@ export function HistorySidebar({ conversations, activeId, onNew, onSelect, onDel
         <span className="try-brand-name">Franklin</span>
       </button>
 
-      <div className="try-space-switch" role="group" aria-label="Conversation mode">
-        <button
-          className={chatSpace === "personal" ? "is-active" : ""}
-          onClick={() => onChatSpace("personal")}
-          title="Your private conversations"
-        >
-          <UserRound className="h-4 w-4" />
-          Personal
-        </button>
-        <button
-          className={chatSpace === "team" ? "is-active" : ""}
-          onClick={() => onChatSpace("team")}
-          disabled={!teamModeEnabled}
-          title="Shared BlockRun team conversations"
-        >
-          <Users className="h-4 w-4" />
-          Team
-          <span className="try-team-beta">Beta</span>
-        </button>
-      </div>
-
-      {!teamModeEnabled && <button className="try-team-disabled-note" onClick={() => onView("agents")}>Team Mode is off · Manage modules</button>}
-
-      {chatSpace === "team" && <div className="try-team-workspaces">
-        <div className="try-team-workspaces-head"><span>WORKSPACES</span><em>{teamWorkspaces.length}</em></div>
-        {teamLoading ? <div className="try-team-workspace-loading">Connecting to Franklin Cloud…</div> : teamWorkspaces.length === 0 ? <div className="try-team-workspace-loading">No team workspaces yet</div> : teamWorkspaces.map((workspace) => (
-          <button key={workspace.id} className={`try-team-workspace${activeTeamWorkspaceId === workspace.id && view === "chat" ? " is-active" : ""}`} onClick={() => onTeamWorkspace?.(workspace.id)}>
-            <span className="try-team-mark"><Cloud className="h-4 w-4" /></span>
-            <span><strong>{workspace.name}</strong><small>{workspace.memberCount} members · {workspace.role}</small></span>
-            <i aria-label={`Workspace version ${workspace.version}`}>v{workspace.version}</i>
-          </button>
-        ))}
-      </div>}
-
-      <button className="try-nav-item" onClick={onNew}>
+      <button className="try-nav-item" onClick={onNewChat}>
         <Plus className="h-4 w-4" />
-        {chatSpace === "team" ? "New workspace" : t.newChat}
+        {t.newChat}
       </button>
 
-      {chatSpace === "personal" && <button className="try-nav-item" onClick={() => setSearchOpen(true)}>
+      <button className="try-nav-item" onClick={() => setSearchOpen(true)}>
         <Search className="h-4 w-4" />
         {t.searchChats}
-      </button>}
+      </button>
 
       <div className="try-scroll">
-      {nav.map((n) => (
-        <button
-          key={n.key}
-          className={`try-nav-item${view === n.key ? " is-active" : ""}`}
-          onClick={() => onView(n.key)}
-        >
-          {n.icon}
-          {n.label}
+        <button className={`try-nav-item${view === "agents" ? " is-active" : ""}`} onClick={() => onView("agents")}>
+          <Bot className="h-4 w-4" />
+          Agents
         </button>
-      ))}
 
-      {moreNav.length > 0 && <button
-        ref={moreBtnRef}
-        className={`try-nav-item try-more-btn${moreActive ? " is-active" : ""}`}
-        onClick={() => (moreOpen ? setMoreOpen(false) : openMore())}
-      >
-        <Grid2x2 className="h-4 w-4" />
-        <span className="try-more-label">{t.more}</span>
-        <ChevronRight className="try-more-chevron h-4 w-4" />
-      </button>}
+        <button
+          className="try-nav-item try-project-create"
+          onClick={onNewProject}
+          disabled={!teamModeEnabled}
+          title={teamModeEnabled ? "Create or join a project" : "Enable Team Mode in Agents"}
+        >
+          <FolderPlus className="h-4 w-4" />
+          New project
+        </button>
 
-      {chatSpace === "personal" && <div className="try-history">
-        {sorted.length === 0 ? (
-          <p className="try-history-empty">{t.noConversations}</p>
-        ) : (
-          <div className="try-history-group">
-            <div className="try-history-group-label">{t.history}</div>
-            {sorted.map((c) => (
-              <div
-                key={c.id}
-                className={`try-history-item${c.id === activeId && view === "chat" ? " is-active" : ""}`}
-                onClick={() => {
-                  onSelect(c.id);
-                  onView("chat");
-                }}
-              >
-                <MessageSquare className="try-history-icon" />
-                <span className="try-history-title">{c.title || "New chat"}</span>
-                <button
-                  className="try-history-del"
-                  aria-label="Delete conversation"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onDelete(c.id);
-                  }}
-                >
-                  <Trash2 className="h-3.5 w-3.5" />
-                </button>
-              </div>
-            ))}
-          </div>
-        )}
-      </div>}
+        {!teamModeEnabled && <button className="try-team-disabled-note" onClick={() => onView("agents")}>Team Mode is off · Manage modules</button>}
+
+        <SidebarSection label="Pinned" count={pinned.length}>
+          {pinned.map((conversation) => (
+            <ConversationRow
+              key={conversation.id}
+              conversation={conversation}
+              active={chatSpace === "personal" && conversation.id === activeId && view === "chat"}
+              onSelect={onSelect}
+              onDelete={onDelete}
+              onTogglePinned={onTogglePinned}
+            />
+          ))}
+        </SidebarSection>
+
+        <SidebarSection label="Projects" count={teamWorkspaces.length}>
+          {teamLoading ? (
+            <p className="try-section-empty">Connecting…</p>
+          ) : teamWorkspaces.length === 0 ? (
+            <p className="try-section-empty">No projects</p>
+          ) : teamWorkspaces.map((workspace) => (
+            <button
+              key={workspace.id}
+              className={`try-team-workspace${chatSpace === "team" && activeTeamWorkspaceId === workspace.id && view === "chat" ? " is-active" : ""}`}
+              onClick={() => onTeamWorkspace?.(workspace.id)}
+              disabled={!teamModeEnabled}
+              title={teamModeEnabled ? `${workspace.memberCount} members · ${workspace.role}` : "Enable Team Mode in Agents"}
+            >
+              <Folder className="h-4 w-4" />
+              <span>{workspace.name}</span>
+            </button>
+          ))}
+        </SidebarSection>
+
+        <SidebarSection label="Recent" count={recent.length}>
+          {recent.length === 0 && sorted.length === 0 ? (
+            <p className="try-section-empty">{t.noConversations}</p>
+          ) : recent.map((conversation) => (
+            <ConversationRow
+              key={conversation.id}
+              conversation={conversation}
+              active={chatSpace === "personal" && conversation.id === activeId && view === "chat"}
+              onSelect={onSelect}
+              onDelete={onDelete}
+              onTogglePinned={onTogglePinned}
+            />
+          ))}
+        </SidebarSection>
+
+        <div className="try-sidebar-secondary">
+          {nav.map((n) => (
+            <button
+              key={n.key}
+              className={`try-nav-item${view === n.key ? " is-active" : ""}`}
+              onClick={() => onView(n.key)}
+            >
+              {n.icon}
+              {n.label}
+            </button>
+          ))}
+
+          {moreNav.length > 0 && <button
+            ref={moreBtnRef}
+            className={`try-nav-item try-more-btn${moreActive ? " is-active" : ""}`}
+            onClick={() => (moreOpen ? setMoreOpen(false) : openMore())}
+          >
+            <Grid2x2 className="h-4 w-4" />
+            <span className="try-more-label">{t.more}</span>
+            <ChevronRight className="try-more-chevron h-4 w-4" />
+          </button>}
+        </div>
       </div>
 
       <div className="try-sidebar-footer">
@@ -226,12 +227,64 @@ export function HistorySidebar({ conversations, activeId, onNew, onSelect, onDel
           setSearchOpen(false);
         }}
         onNew={() => {
-          onNew();
+          onNewChat();
           setSearchOpen(false);
         }}
       />
     )}
     </>
+  );
+}
+
+function SidebarSection({ label, count, children }: { label: string; count: number; children: React.ReactNode }) {
+  return (
+    <section className="try-sidebar-section">
+      <div className="try-sidebar-section-head">
+        <span>{label}</span>
+        {count > 0 && <em>{count}</em>}
+      </div>
+      <div className="try-sidebar-section-items">{children}</div>
+    </section>
+  );
+}
+
+function ConversationRow({ conversation, active, onSelect, onDelete, onTogglePinned }: {
+  conversation: Conversation;
+  active: boolean;
+  onSelect: (id: string) => void;
+  onDelete: (id: string) => void;
+  onTogglePinned: (id: string) => void;
+}) {
+  const isPinned = !!conversation.pinnedAt;
+  return (
+    <div className={`try-history-item${active ? " is-active" : ""}`} onClick={() => onSelect(conversation.id)}>
+      <MessageSquare className="try-history-icon" />
+      <span className="try-history-title">{conversation.title || "New chat"}</span>
+      <span className="try-history-actions">
+        <button
+          className={`try-history-action${isPinned ? " is-pinned" : ""}`}
+          aria-label={isPinned ? "Unpin conversation" : "Pin conversation"}
+          title={isPinned ? "Unpin" : "Pin"}
+          onClick={(event) => {
+            event.stopPropagation();
+            onTogglePinned(conversation.id);
+          }}
+        >
+          {isPinned ? <PinOff className="h-3.5 w-3.5" /> : <Pin className="h-3.5 w-3.5" />}
+        </button>
+        <button
+          className="try-history-action try-history-del"
+          aria-label="Delete conversation"
+          title="Delete"
+          onClick={(event) => {
+            event.stopPropagation();
+            onDelete(conversation.id);
+          }}
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </button>
+      </span>
+    </div>
   );
 }
 

--- a/apps/desktop/src/hooks/use-chat-history.ts
+++ b/apps/desktop/src/hooks/use-chat-history.ts
@@ -143,8 +143,9 @@ export function useChatHistory(address: string | null, space: ChatSpace = "perso
   }, [setActiveChatForSpace]);
 
   const togglePinned = useCallback((id: string) => {
+    const now = Date.now();
     setConversations((prev) => prev.map((conversation) => conversation.id === id
-      ? { ...conversation, pinnedAt: conversation.pinnedAt ? undefined : Date.now() }
+      ? { ...conversation, pinnedAt: conversation.pinnedAt ? undefined : now, updatedAt: now }
       : conversation));
   }, []);
 

--- a/apps/desktop/src/hooks/use-chat-history.ts
+++ b/apps/desktop/src/hooks/use-chat-history.ts
@@ -24,6 +24,8 @@ export interface Conversation {
   messages: ChatMessage[];
   /** Missing on older records, which are migrated as personal conversations. */
   space?: ChatSpace;
+  /** Unix timestamp used to order conversations pinned in the sidebar. */
+  pinnedAt?: number;
 }
 
 type Setter = ChatMessage[] | ((prev: ChatMessage[]) => ChatMessage[]);
@@ -120,11 +122,31 @@ export function useChatHistory(address: string | null, space: ChatSpace = "perso
   }, [conversations, signedIn]);
 
   const visibleConversations = conversations.filter((c) => conversationSpace(c) === space);
+  const personalConversations = conversations.filter((c) => conversationSpace(c) === "personal");
   const activeConversation = visibleConversations.find((c) => c.id === activeId) ?? null;
   const messages = activeConversation?.messages ?? [];
 
   const newChat = useCallback(() => setActiveId(null), [setActiveId]);
   const selectChat = useCallback((id: string) => setActiveId(id), [setActiveId]);
+
+  const setActiveChatForSpace = useCallback((targetSpace: ChatSpace, id: string | null) => {
+    activeBySpaceRef.current = { ...activeBySpaceRef.current, [targetSpace]: id };
+    setActiveBySpace((prev) => ({ ...prev, [targetSpace]: id }));
+  }, []);
+
+  const newChatInSpace = useCallback((targetSpace: ChatSpace) => {
+    setActiveChatForSpace(targetSpace, null);
+  }, [setActiveChatForSpace]);
+
+  const selectChatInSpace = useCallback((targetSpace: ChatSpace, id: string) => {
+    setActiveChatForSpace(targetSpace, id);
+  }, [setActiveChatForSpace]);
+
+  const togglePinned = useCallback((id: string) => {
+    setConversations((prev) => prev.map((conversation) => conversation.id === id
+      ? { ...conversation, pinnedAt: conversation.pinnedAt ? undefined : Date.now() }
+      : conversation));
+  }, []);
 
   const renameChat = useCallback((id: string, title: string) => {
     const clean = title.trim().slice(0, 80) || "New chat";
@@ -134,9 +156,10 @@ export function useChatHistory(address: string | null, space: ChatSpace = "perso
   const deleteChat = useCallback(
     (id: string) => {
       setConversations((prev) => prev.filter((c) => c.id !== id));
-      if (activeBySpaceRef.current[space] === id) setActiveId(null);
+      if (activeBySpaceRef.current.personal === id) setActiveChatForSpace("personal", null);
+      if (activeBySpaceRef.current.team === id) setActiveChatForSpace("team", null);
     },
-    [setActiveId, space],
+    [setActiveChatForSpace],
   );
 
   const deleteMedia = useCallback(
@@ -214,5 +237,22 @@ export function useChatHistory(address: string | null, space: ChatSpace = "perso
     [setActiveId, space],
   );
 
-  return { conversations, visibleConversations, activeId, activeConversation, messages, setMessages, ensureConvId, newChat, selectChat, deleteChat, renameChat, deleteMedia };
+  return {
+    conversations,
+    visibleConversations,
+    personalConversations,
+    activeId,
+    activeConversation,
+    messages,
+    setMessages,
+    ensureConvId,
+    newChat,
+    newChatInSpace,
+    selectChat,
+    selectChatInSpace,
+    togglePinned,
+    deleteChat,
+    renameChat,
+    deleteMedia,
+  };
 }

--- a/apps/desktop/src/hooks/use-cloud-workspace.ts
+++ b/apps/desktop/src/hooks/use-cloud-workspace.ts
@@ -193,3 +193,5 @@ export function useCloudWorkspace() {
     refreshActive,
   };
 }
+
+export type CloudWorkspaceController = ReturnType<typeof useCloudWorkspace>;

--- a/apps/desktop/src/styles/globals.css
+++ b/apps/desktop/src/styles/globals.css
@@ -4708,18 +4708,12 @@ h2.dark-h,
   background: #34a853;
   box-shadow: 0 0 0 3px color-mix(in oklch, #34a853 15%, transparent);
 }
-.try-team-workspaces { display: grid; gap: 4px; margin: 1px 2px 7px; }
-.try-team-workspaces-head { display: flex; align-items: center; justify-content: space-between; padding: 2px 7px 4px; color: var(--fg-subtle); font-size: 9px; font-weight: 750; letter-spacing: .09em; }
-.try-team-workspaces-head em { min-width: 18px; height: 18px; display: grid; place-items: center; padding: 0 5px; border: 1px solid var(--border); border-radius: 999px; font-style: normal; letter-spacing: 0; }
-.try-team-workspace { display: grid; grid-template-columns: 30px minmax(0,1fr) auto; align-items: center; gap: 8px; width: 100%; padding: 8px; border: 1px solid transparent; border-radius: 10px; background: transparent; color: var(--fg); text-align: left; cursor: pointer; }
+.try-team-workspace { display: flex; align-items: center; gap: 8px; width: 100%; min-height: 30px; padding: 5px 9px; border: 1px solid transparent; border-radius: 7px; background: transparent; color: var(--fg-muted); text-align: left; cursor: pointer; }
 .try-team-workspace:hover { background: var(--bg-hover); }
-.try-team-workspace.is-active { border-color: var(--gold-line); background: linear-gradient(135deg,var(--gold-soft),color-mix(in oklch,var(--bg) 90%,transparent)); }
-.try-team-workspace > span:nth-child(2) { min-width: 0; }
-.try-team-workspace strong,.try-team-workspace small { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.try-team-workspace strong { font-size: 11.5px; line-height: 1.3; }
-.try-team-workspace small { margin-top: 2px; color: var(--fg-subtle); font-size: 9px; text-transform: capitalize; }
-.try-team-workspace > i { color: var(--fg-subtle); font-family: var(--font-mono); font-size: 8px; font-style: normal; }
-.try-team-workspace-loading { padding: 12px 8px; border: 1px dashed var(--border); border-radius: 9px; color: var(--fg-subtle); font-size: 10px; line-height: 1.4; text-align: center; }
+.try-team-workspace.is-active { border-color: var(--border); background: var(--bg); color: var(--fg); }
+.try-team-workspace svg { flex-shrink: 0; color: var(--fg-subtle); }
+.try-team-workspace span { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 13px; }
+.try-team-workspace:disabled { opacity: .42; cursor: not-allowed; }
 
 /* Sidebar nav item (Phone panel) */
 .try-nav-item {
@@ -4739,6 +4733,8 @@ h2.dark-h,
   transition: background 0.12s, color 0.12s, border-color 0.12s;
 }
 .try-nav-item:hover { background: rgba(0, 0, 0, 0.04); color: var(--fg); }
+.try-nav-item:disabled { opacity: .42; cursor: not-allowed; }
+.try-nav-item:disabled:hover { background: transparent; color: var(--fg-muted); }
 .try-nav-item svg { color: var(--gold-dim); }
 .try-nav-item.is-active {
   background: var(--gold-soft);
@@ -5776,12 +5772,33 @@ h2.dark-h,
   flex: 1;
   min-height: 0;
   overflow-y: auto;
+  overflow-x: hidden;
   display: flex;
   flex-direction: column;
-  gap: 3px;
+  gap: 1px;
   margin: 2px -4px 0;
   padding: 0 4px;
 }
+.try-sidebar-section { margin-top: 3px; }
+.try-sidebar-section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 24px;
+  padding: 5px 8px 3px;
+  color: var(--fg-subtle);
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  font-weight: 650;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+.try-sidebar-section-head em { font-style: normal; font-size: 9px; letter-spacing: 0; }
+.try-sidebar-section-items { display: grid; gap: 1px; }
+.try-section-empty { margin: 0; padding: 4px 9px 6px; color: var(--fg-subtle); font-size: 11px; }
+.try-sidebar-secondary { display: grid; gap: 1px; margin-top: 7px; padding-top: 7px; border-top: 1px solid var(--border); }
+.try-project-create { color: var(--fg); }
+.try-project-create svg { color: var(--gold-dim); }
 .try-history { display: flex; flex-direction: column; gap: 1px; }
 .try-history-empty {
   font-size: 13px;
@@ -5791,9 +5808,12 @@ h2.dark-h,
 .try-history-item {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 6px 10px;
-  border-radius: 8px;
+  gap: 7px;
+  min-height: 30px;
+  width: 100%;
+  min-width: 0;
+  padding: 4px 7px 4px 9px;
+  border-radius: 7px;
   cursor: pointer;
   color: var(--fg-muted);
   white-space: nowrap;
@@ -5804,23 +5824,43 @@ h2.dark-h,
 .try-history-icon { width: 15px; height: 15px; flex-shrink: 0; color: var(--fg-subtle); }
 .try-history-title {
   flex: 1;
-  font-size: 13.5px;
+  min-width: 0;
+  font-size: 13px;
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.try-history-del {
+.try-history-actions {
   display: inline-flex;
-  padding: 4px;
+  align-items: center;
+  justify-content: flex-end;
+  width: 45px;
+  flex-shrink: 0;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.12s;
+}
+.try-history-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
   border: none;
   background: none;
   color: var(--fg-subtle);
   cursor: pointer;
-  opacity: 0;
-  border-radius: 6px;
-  transition: opacity 0.12s, color 0.12s;
+  border-radius: 5px;
+  transition: background 0.12s, color 0.12s;
 }
-.try-history-item:hover .try-history-del { opacity: 1; }
+.try-history-item:hover .try-history-actions,
+.try-history-item:focus-within .try-history-actions { opacity: 1; pointer-events: auto; }
+.try-history-action:hover { background: var(--bg); color: var(--fg); }
+.try-history-action.is-pinned { color: var(--gold-dim); }
 .try-history-del:hover { color: #9a3412; }
+@media (hover: none) {
+  .try-history-actions { opacity: 1; pointer-events: auto; }
+}
 
 /* Bar left cluster */
 .try-bar-left { display: flex; align-items: center; gap: 12px; }

--- a/src/serve/cloud-sync.ts
+++ b/src/serve/cloud-sync.ts
@@ -25,6 +25,7 @@ export interface CloudConversation {
   createdAt: number;
   updatedAt: number;
   messages: unknown[];
+  pinnedAt?: number;
 }
 
 export function isCloudSyncEnabled(): boolean {


### PR DESCRIPTION
## Summary
- remove the Personal/Team switch and use direct sidebar navigation
- place Agents, New project, Pinned, Projects, and Recent in a compact Codex-style hierarchy
- add persistent pin/unpin support for conversations
- keep project navigation live by sharing the Cloud workspace controller with the main desktop shell

## Validation
- npm run typecheck --workspace @blockrun/franklin-desktop
- npm run lint --workspace @blockrun/franklin-desktop
- npm run build --workspace @blockrun/franklin-desktop
- npm test --workspace @blockrun/franklin-desktop
- desktop and 760px responsive visual checks

Ready for review.