### PR TITLE
fix(desktop): repair sidebar regressions from #147

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockrun/franklin-desktop",
-  "version": "0.2.0-beta.1",
+  "version": "0.2.0-beta.2",
   "description": "Franklin Desktop — native desktop app for the Franklin agent (Electron). Same agent, wallet and tools as the CLI, in a polished window.",
   "license": "Apache-2.0",
   "type": "module",

--- a/apps/desktop/src/components/CloudWorkspacePanel.tsx
+++ b/apps/desktop/src/components/CloudWorkspacePanel.tsx
@@ -65,8 +65,8 @@ export function CloudWorkspacePanel({ cloud }: { cloud: CloudWorkspaceController
           <div className="cloud-kicker">FRANKLIN CLOUD · TEAM WORKSPACE</div>
           <h2>{cloud.connected ? "Connect your Franklin wallet" : "Start Franklin to continue"}</h2>
           <p>Your local Franklin signs in to franklin.run with SIWE. The wallet key never leaves this computer; Team data is stored in the existing Franklin Cloud.</p>
-          <button className="cloud-primary" disabled={!cloud.connected || cloud.loading} onClick={() => void cloud.connect()}>
-            {cloud.loading ? <Loader2 className="spin" /> : <ShieldCheck />} {cloud.connected ? "Connect Franklin Cloud" : "Franklin is offline"}
+          <button className="cloud-primary" disabled={cloud.loading} onClick={() => void cloud.connect()}>
+            {cloud.loading ? <Loader2 className="spin" /> : <ShieldCheck />} {cloud.connected ? "Connect Franklin Cloud" : "Retry connection"}
           </button>
           {cloud.error && <div className="cloud-error">{friendlyCloudError(cloud.error)}</div>}
         </div>

--- a/apps/desktop/src/components/FranklinChat.tsx
+++ b/apps/desktop/src/components/FranklinChat.tsx
@@ -3,7 +3,7 @@
 // rewired to the local agent: useFranklinChat streams over the WebSocket, the
 // wallet is the local CLI wallet (read-only, no connect flow).
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { ArrowUp, PanelLeft, ImageIcon, Clapperboard, Music, X, Plus, Check, ChevronDown, Gauge, BarChart3, TrendingUp, MoreHorizontal, Users, Laptop2, ShieldAlert } from "lucide-react";
 import { TopBarMenu } from "./TopBarMenu";
 import { ModelSelect } from "./ModelSelect";
@@ -86,8 +86,8 @@ export function FranklinChat() {
   const history = useChatHistory(auth.address, chatSpace);
   const usage = useSpend();
   const studio = useStudioRegistry();
-  const cloud = useCloudWorkspace();
-  const teamNav = {
+  const cloud = useCloudWorkspace({ enabled: studio.teamModeEnabled, viewing: chatSpace === "team" });
+  const teamNav = useMemo(() => ({
     items: cloud.workspaces.map((workspace) => ({
       id: workspace.id,
       name: workspace.name,
@@ -97,7 +97,7 @@ export function FranklinChat() {
     })),
     activeId: cloud.activeId,
     loading: cloud.loading && !cloud.session,
-  };
+  }), [cloud.workspaces, cloud.activeId, cloud.loading, cloud.session]);
   const chat = useFranklinChat(history.messages, history.setMessages, history.ensureConvId);
   const { mode, setMode, model, setModel, models, selectedModel, status, activeTool, needsToolWallet, genConvId, mediaJobs, error, pendingPermission, respondToPermission, isBusy, isConnected, send, stop, stopMedia, regenerate, imageSize, setImageSize, imageSizes, videoRatio, setVideoRatio, videoRatios, videoResolution, setVideoResolution, videoResolutions } = chat;
   const genHere = genConvId === null || genConvId === history.activeId;
@@ -374,7 +374,7 @@ export function FranklinChat() {
           )}
         </div>
 
-        {chatSpace === "team" && view === "chat" ? (
+        {chatSpace === "team" && studio.teamModeEnabled && view === "chat" ? (
           <CloudWorkspacePanel cloud={cloud} />
         ) : view === "agents" ? (
           <AgentsPanel
@@ -404,7 +404,7 @@ export function FranklinChat() {
         ) : view === "mcp" ? (
           <McpPanel />
         ) : view === "gallery" ? (
-          <GalleryPanel conversations={history.visibleConversations} onZoom={setLightbox} onDelete={history.deleteMedia} />
+          <GalleryPanel conversations={history.personalConversations} onZoom={setLightbox} onDelete={history.deleteMedia} />
         ) : view === "wallet" ? (
           <WalletPanel usage={usage} />
         ) : (

--- a/apps/desktop/src/components/HistorySidebar.tsx
+++ b/apps/desktop/src/components/HistorySidebar.tsx
@@ -67,7 +67,7 @@ export function HistorySidebar({ conversations, activeId, onNewChat, onNewProjec
     { key: "gallery", icon: <Images className="h-4 w-4" />, label: t.gallery },
     { key: "cli", icon: <Terminal className="h-4 w-4" />, label: t.cli },
   ];
-  const nav = navItems.filter((item) => visibleItems.includes(item.key as "agents" | "tools" | "gallery" | "cli"));
+  const nav = navItems.filter((item) => visibleItems.includes(item.key as "tools" | "gallery" | "cli"));
   const moreNavItems: { key: TryView; icon: React.ReactNode; label: string }[] = [
     { key: "mcp", icon: <Server className="h-4 w-4" />, label: "MCP" },
     { key: "skills", icon: <Sparkles className="h-4 w-4" />, label: t.skills },
@@ -98,10 +98,10 @@ export function HistorySidebar({ conversations, activeId, onNewChat, onNewProjec
       </button>
 
       <div className="try-scroll">
-        <button className={`try-nav-item${view === "agents" ? " is-active" : ""}`} onClick={() => onView("agents")}>
+        {visibleItems.includes("agents") && <button className={`try-nav-item${view === "agents" ? " is-active" : ""}`} onClick={() => onView("agents")}>
           <Bot className="h-4 w-4" />
           Agents
-        </button>
+        </button>}
 
         <button
           className="try-nav-item try-project-create"

--- a/apps/desktop/src/hooks/use-cloud-workspace.ts
+++ b/apps/desktop/src/hooks/use-cloud-workspace.ts
@@ -49,7 +49,16 @@ async function agentTurn(workspaceId: string, content: string): Promise<void> {
   if (!response.ok) throw new Error(result.error || `Team Franklin failed (${response.status})`);
 }
 
-export function useCloudWorkspace() {
+export interface CloudWorkspaceOptions {
+  /** Team Mode toggle. When off, Franklin never reaches the cloud service. */
+  enabled?: boolean;
+  /** True while the team workspace UI is on screen. Gates the snapshot fetch and
+   *  drives the connect retry, so a service that started after the app did is
+   *  still reachable without a restart. */
+  viewing?: boolean;
+}
+
+export function useCloudWorkspace({ enabled = true, viewing = false }: CloudWorkspaceOptions = {}) {
   const [connected, setConnected] = useState(false);
   const [session, setSession] = useState<CloudUser | null>(null);
   const [workspaces, setWorkspaces] = useState<CloudWorkspace[]>([]);
@@ -108,6 +117,10 @@ export function useCloudWorkspace() {
   }, [activeId]);
 
   const connect = useCallback(async () => {
+    // Guarded here rather than at each call site: `connect` is exposed on the
+    // controller (the panel's Retry button calls it), so Team Mode has to hold
+    // at the one place every path routes through.
+    if (!enabled) return;
     setLoading(true); setError(null);
     try {
       const base = window.__FRANKLIN__?.cloudUrl || "http://127.0.0.1:3740";
@@ -124,15 +137,37 @@ export function useCloudWorkspace() {
       setError(reason instanceof Error ? reason.message : String(reason));
     }
     finally { setLoading(false); }
-  }, [refreshWorkspaces]);
+  }, [enabled, refreshWorkspaces]);
 
-  useEffect(() => { void connect(); }, [connect]);
-
+  // `session` is the liveness signal: it is set only after a successful
+  // workspace.list. A failed attempt leaves it null, so opening the team UI
+  // retries instead of stranding the user on a dead controller until restart.
   useEffect(() => {
+    if (!enabled || session) return;
+    void connect();
+  }, [connect, enabled, session, viewing]);
+
+  // Team Mode off means off: drop anything already fetched so the sidebar does
+  // not keep listing projects the user just disabled.
+  useEffect(() => {
+    if (enabled) return;
+    setConnected(false);
+    setSession(null);
+    setWorkspaces([]);
+    setMessages([]);
+    setFiles([]);
+    setError(null);
+    contentWorkspaceRef.current = null;
+  }, [enabled]);
+
+  // Pulling a full snapshot (every message + file) is deferred until the team UI
+  // is actually open — booting the app should not fetch a project nobody opened.
+  useEffect(() => {
+    if (!enabled || !viewing) return;
     if (!connected || !session || !activeId) return;
     setLoading(true);
     refreshActive().finally(() => setLoading(false));
-  }, [activeId, connected, refreshActive, session]);
+  }, [activeId, connected, enabled, refreshActive, session, viewing]);
 
   const createWorkspace = async (name: string) => {
     setLoading(true); setError(null);

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
     },
     "apps/desktop": {
       "name": "@blockrun/franklin-desktop",
-      "version": "0.2.0-beta.1",
+      "version": "0.2.0-beta.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@blockrun/franklin": "*",


### PR DESCRIPTION
Follow-up to #147. Three user-visible regressions plus the Team Mode bypass the `useCloudWorkspace` hoist introduced. Found by a post-merge `/review` pass on `a79fc10`.

## Cloud connect could not be retried

Hoisting `useCloudWorkspace()` to the app root meant `connect()` ran exactly once at boot. If `127.0.0.1:3740` was not up at that instant, `connected` stayed `false` for the whole session and the panel's Connect button was `disabled={!cloud.connected}` reading "Franklin is offline" — only an app restart recovered. Before #147 the hook mounted on entering team space, so switching Personal → Team retried.

The connect effect now keys on `session` (set only after a successful `workspace.list`) and re-runs when the team UI opens. The panel's button is enabled whenever it isn't mid-flight and reads "Retry connection".

## The Agents sidebar-visibility toggle was dead

Agents moved out of `navItems` and became a hardcoded button, so `visibleItems` no longer gated it — while `MoreMenu.tsx:120` still renders a switch for it from `SIDEBAR_ITEMS`. Hiding Agents cleared the checkmark and changed nothing. Now gated on `visibleItems.includes("agents")`.

## Gallery emptied after opening a Project

`GalleryPanel` still read space-scoped `visibleConversations` while the sidebar had moved to `personalConversations`. Clicking a Project sets `chatSpace="team"`, so Pinned/Recent kept showing personal chats while Gallery showed team ones — empty for essentially everyone. Gallery now reads `personalConversations`.

## Team Mode off no longer reaches the cloud

The hook took no account of `teamModeEnabled` (a persisted user toggle). Every launch ran `/health` + `workspace.list`, auto-selected `workspaces[0]` into localStorage, and pulled a full `workspace.snapshot` (all messages + files) for a project nobody opened. The sidebar only disabled the buttons.

`useCloudWorkspace` now takes `{ enabled, viewing }`:
- `enabled` gates `connect()` at the source — the panel's Retry routes through it, so the guard holds for every path — and clears fetched state when Team Mode is switched off.
- `viewing` defers the snapshot until the team UI is actually on screen.

Also memoizes `teamNav`, which was reallocated on every render.

## Verification

- `tsc -b --noEmit` clean. Note: `npm run typecheck` fails with `TS5102: Option 'baseUrl' has been removed` on `main` as well — the repo root hoists `typescript@7.0.2` while `apps/desktop` declares `^5.9.3`. Pre-existing, unrelated to this change; verified against TS 5.9.3.
- `eslint src` clean
- `vite build` clean
- `npm test --workspace @blockrun/franklin-desktop` — security, cloud, and team-proxy suites all pass

## Not addressed here

Left for a separate pass: sidebar section labels are hardcoded English ("Pinned"/"Recent"/"Projects") while `t.history` still exists unused in all three locales; unpinning bumps `updatedAt` so the chat jumps to the top of Recent (the bump is load-bearing for cloud sync, so it needs a separate sort key, not a deletion); `lib/team-workspace-events.ts` is now dead except for one type; empty Pinned/Projects sections render a bare header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdbfY8FiReoKH32UKeKfzN