### PR TITLE
ci(desktop): guard the installers and version-pin release notes

### DIFF
--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -77,12 +77,27 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Check out release notes
+        uses: actions/checkout@v4
+
       - name: Download installers
         uses: actions/download-artifact@v4
         with:
           pattern: franklin-desktop-*
           path: release
           merge-multiple: true
+
+      - name: Verify both installers are present
+        shell: bash
+        run: |
+          shopt -s nullglob
+          dmg=(release/*.dmg)
+          exe=(release/*.exe)
+          if (( ${#dmg[@]} != 1 || ${#exe[@]} != 1 )); then
+            echo "::error::expected exactly one .dmg and one .exe, got ${#dmg[@]} dmg / ${#exe[@]} exe"
+            ls -la release/
+            exit 1
+          fi
 
       - name: Generate checksums
         shell: bash
@@ -96,15 +111,26 @@ jobs:
       - name: Prepare release metadata
         id: release-meta
         shell: bash
-        run: echo "name=Franklin Desktop ${GITHUB_REF_NAME#desktop-v}" >> "$GITHUB_OUTPUT"
+        run: |
+          version="${GITHUB_REF_NAME#desktop-v}"
+          echo "name=Franklin Desktop $version" >> "$GITHUB_OUTPUT"
+          notes="apps/desktop/release-notes/${version}.md"
+          if [[ -f "$notes" ]]; then
+            echo "using $notes"
+            cp "$notes" release-body.md
+          else
+            echo "no $notes, falling back to the generic blurb"
+            cat > release-body.md <<'EOF'
+          Franklin Desktop beta for macOS Apple Silicon and Windows x64.
+
+          These beta installers are currently unsigned. On first launch, your operating system may ask you to confirm that you want to open the app.
+          EOF
+          fi
 
       - name: Publish Desktop prerelease
         uses: softprops/action-gh-release@v2
         with:
           name: ${{ steps.release-meta.outputs.name }}
           prerelease: true
-          body: |
-            Franklin Desktop beta for macOS Apple Silicon and Windows x64.
-
-            These beta installers are currently unsigned. On first launch, your operating system may ask you to confirm that you want to open the app.
+          body_path: release-body.md
           files: release/*

--- a/apps/desktop/release-notes/0.2.0-beta.2.md
+++ b/apps/desktop/release-notes/0.2.0-beta.2.md
@@ -1,0 +1,18 @@
+Franklin Desktop Beta for macOS Apple Silicon and Windows x64.
+
+## What's fixed
+
+This release repairs four regressions from the sidebar reorganization in 0.2.0 Beta 1.
+
+- **Franklin Cloud can reconnect.** If the local Franklin service was not running when the app started, Projects stayed empty and the Connect button was stuck reading "Franklin is offline" until you restarted the app. It now retries when you open a project.
+- **The Agents sidebar toggle works again.** Hiding Agents from the sidebar cleared the checkmark but left the button in place.
+- **Gallery no longer empties after opening a Project.** Your generated images and video stayed hidden until you switched back to a personal chat.
+- **Team Mode off now means off.** With Team Mode disabled the app was still contacting the cloud service on every launch and pre-loading a project you never opened.
+
+## Downloads
+
+- `Franklin-0.2.0-beta.2-arm64.dmg` for Apple Silicon Macs
+- `Franklin.Setup.0.2.0-beta.2.exe` for Windows x64
+- `SHA256SUMS.txt` for download verification
+
+These beta installers are currently unsigned. On first launch, macOS or Windows may ask you to confirm that you want to open the app.

--- a/apps/desktop/release-notes/README.md
+++ b/apps/desktop/release-notes/README.md
@@ -1,0 +1,14 @@
+# Desktop release notes
+
+`desktop-ci.yml` publishes the release body from `<version>.md` in this
+directory, where `<version>` is the tag with the `desktop-v` prefix stripped —
+so tag `desktop-v0.2.0-beta.2` reads `0.2.0-beta.2.md`.
+
+Write the notes here in the same PR as the version bump. Two reasons:
+
+- Re-running the release job reproduces the same body. The workflow used to
+  carry a hardcoded blurb, so a re-run silently replaced notes written by hand
+  on the release page.
+- The filename carries the version, so notes cannot go stale against a newer
+  tag. A tag with no matching file falls back to a generic blurb rather than
+  publishing the previous release's notes.


### PR DESCRIPTION
Two gaps in `desktop-ci.yml`'s release job, found reviewing #146 while cutting `desktop-v0.2.0-beta.2`.

Worth noting up front: #146's own fix is **verified working**. Its first-ever production run was beta.2, and the CI-generated `SHA256SUMS.txt` hashes match GitHub's asset digests exactly, with filenames matching the uploaded assets (`Franklin.Setup.0.2.0-beta.2.exe`). This PR addresses what that code does not cover.

## Nothing checked that both installers arrived

`download-artifact` does not fail when its `pattern` matches no artifacts, so a partial download would publish a release with one installer plus a `SHA256SUMS.txt` that looks complete — the checksum step succeeds either way. Adds an explicit count check for exactly one `.dmg` and one `.exe` before anything is hashed or uploaded.

## Release notes were destroyed by re-runs

The body was a hardcoded two-sentence blurb in the workflow. `action-gh-release` updates an existing release, so notes written by hand on the release page were silently replaced the moment the job was re-run. And since every release got the same two sentences, **both** beta.1 and beta.2 had to be hand-edited afterward.

The body now comes from `apps/desktop/release-notes/<version>.md`, checked in with the version bump:

- Re-running a release reproduces the same body instead of clobbering it.
- The filename carries the version, so notes cannot go stale against a newer tag — a common failure with a single `RELEASE_NOTES.md`.
- A tag with no matching file falls back to the original blurb rather than failing, so re-running tags that predate this change still works.

`actions/checkout` is added **ahead of** the download step, not after: it cleans the workspace by default and would otherwise delete the installers.

beta.2's published notes are checked in as the first file, so a re-run of that tag now reproduces what is live.

## Verification

Both `run:` scripts were extracted exactly as Actions de-indents the YAML block scalars, then executed:

- notes step, no notes file → falls back to the blurb, `name=Franklin Desktop 0.9.9`
- notes step, notes file present → copies it, `name=Franklin Desktop 0.2.0-beta.3`
- guard, one dmg + one exe → passes
- guard, dmg only / exe only / empty dir → exits 1 in all three

## Not addressed

`softprops/action-gh-release@v2` is a floating major tag on a job holding `contents: write`, so its code changes without review. (Checked: the Node 20 deprecation does **not** apply — `v2`'s `action.yml` currently declares `using: "node24"`. `v3.0.3` exists if you want to pin deliberately.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdbfY8FiReoKH32UKeKfzN