### PR TITLE
test(desktop): add a jsdom unit harness and cover the sidebar regressions

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -15,7 +15,7 @@
     "test:cloud": "node cloud-server/test.mjs",
     "test:team-proxy": "node cloud-server/team-proxy.test.mjs",
     "test:security": "node --test test/*.test.cjs",
-    "test": "npm run test:security && npm run test:cloud && npm run test:team-proxy",
+    "test": "npm run test:unit && npm run test:security && npm run test:cloud && npm run test:team-proxy",
     "cloud:build-sandbox": "docker build -f cloud-server/Dockerfile.sandbox -t franklin-cloud-sandbox:local cloud-server",
     "test:cloud:docker": "npm run cloud:build-sandbox && FRANKLIN_CLOUD_SANDBOX_PROVIDER=docker npm run test:cloud",
     "cloud:compose:up": "docker compose -f cloud-server/compose.yml up --build",
@@ -30,7 +30,8 @@
     "desktop": "npm run build && ELECTRON_RUN_AS_NODE= electron electron/main.cjs",
     "prepare:runtime": "node scripts/prepare-runtime.mjs",
     "dist:mac": "npm run build && npm run prepare:runtime && electron-builder --mac --arm64 --publish never",
-    "dist:win": "npm run build && npm run prepare:runtime && electron-builder --win --x64 --publish never"
+    "dist:win": "npm run build && npm run prepare:runtime && electron-builder --win --x64 --publish never",
+    "test:unit": "vitest run"
   },
   "dependencies": {
     "@blockrun/franklin": "*",
@@ -45,6 +46,8 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.3.0",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.3",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@types/ws": "^8.5.13",
@@ -56,12 +59,14 @@
     "electron-builder": "^26.15.3",
     "eslint": "^9.17.0",
     "eslint-plugin-react-hooks": "^5.1.0",
+    "jsdom": "^29.1.1",
     "shadcn": "^4.8.3",
     "tailwindcss": "^4.3.0",
-    "tw-animate-css": "^1.4.0",
     "ts-api-utils": "2.4.0",
+    "tw-animate-css": "^1.4.0",
     "typescript": "^5.9.3",
     "vite": "^7.3.5",
+    "vitest": "^4.1.11",
     "ws": "^8.18.0"
   },
   "engines": {

--- a/apps/desktop/src/components/HistorySidebar.test.tsx
+++ b/apps/desktop/src/components/HistorySidebar.test.tsx
@@ -1,0 +1,167 @@
+import { render, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../assets/franklin-avatar.png", () => ({ default: "avatar.png" }));
+
+const { HistorySidebar } = await import("./HistorySidebar");
+const { TryLangProvider } = await import("../lib/i18n");
+type Conversation = import("../hooks/use-chat-history").Conversation;
+
+const SIDEBAR_PREFS_KEY = "franklin-sidebar-preferences-v1";
+
+function conversation(over: Partial<Conversation> = {}): Conversation {
+  return {
+    id: "c1",
+    title: "A chat",
+    createdAt: 1_000,
+    updatedAt: 1_000,
+    messages: [],
+    ...over,
+  } as Conversation;
+}
+
+type SidebarProps = Parameters<typeof HistorySidebar>[0];
+
+// Every required prop gets a default here, so `over` only ever narrows. The
+// merge is spelled out rather than spread into JSX because `Partial` widens
+// each field with `undefined`, which a required prop like `wallet` rejects.
+const baseProps: SidebarProps = {
+  conversations: [],
+  activeId: null,
+  onNewChat: () => {},
+  onNewProject: () => {},
+  onSelect: () => {},
+  onDelete: () => {},
+  onTogglePinned: () => {},
+  view: "chat",
+  onView: () => {},
+  open: true,
+  wallet: null,
+  walletLoading: false,
+  walletError: null,
+  walletConnectionState: "open",
+  chatSpace: "personal",
+};
+
+function draw(over: Partial<SidebarProps> = {}) {
+  const props: SidebarProps = { ...baseProps, ...over };
+  return render(
+    <TryLangProvider>
+      <HistorySidebar {...props} />
+    </TryLangProvider>,
+  );
+}
+
+const section = (label: string) =>
+  screen.getByText(label, { selector: ".try-sidebar-section-head span" }).closest("section")!;
+
+beforeEach(() => localStorage.clear());
+
+describe("Agents nav item", () => {
+  // The sidebar reorganization hardcoded this button, so the "Show in sidebar"
+  // preference in MoreMenu cleared its checkmark but left the button rendered.
+  it("is shown by default", () => {
+    draw();
+    expect(screen.getByText("Agents")).toBeTruthy();
+  });
+
+  it("is hidden when the sidebar preference excludes it", () => {
+    localStorage.setItem(SIDEBAR_PREFS_KEY, JSON.stringify(["tools", "gallery", "cli"]));
+    draw();
+    expect(screen.queryByText("Agents")).toBeNull();
+  });
+
+  it("still renders the other nav items when Agents is hidden", () => {
+    localStorage.setItem(SIDEBAR_PREFS_KEY, JSON.stringify(["tools", "gallery", "cli"]));
+    draw();
+    expect(screen.getByText("Gallery")).toBeTruthy();
+  });
+});
+
+describe("Pinned section", () => {
+  // Pinned has no empty-state text, so rendering it empty drew a bare header.
+  it("is not rendered when nothing is pinned", () => {
+    draw({ conversations: [conversation({ id: "a" })] });
+    expect(screen.queryByText("Pinned", { selector: ".try-sidebar-section-head span" })).toBeNull();
+  });
+
+  it("appears once a conversation is pinned", () => {
+    draw({ conversations: [conversation({ id: "a", title: "Pinned one", pinnedAt: 5_000 })] });
+    expect(within(section("Pinned")).getByText("Pinned one")).toBeTruthy();
+  });
+
+  it("orders pinned conversations by when they were pinned", () => {
+    draw({
+      conversations: [
+        conversation({ id: "a", title: "First", pinnedAt: 1_000 }),
+        conversation({ id: "b", title: "Second", pinnedAt: 9_000 }),
+      ],
+    });
+    const titles = within(section("Pinned"))
+      .getAllByText(/First|Second/)
+      .map((n) => n.textContent);
+    expect(titles).toEqual(["Second", "First"]);
+  });
+
+  it("keeps pinned conversations out of Recent", () => {
+    draw({ conversations: [conversation({ id: "a", title: "Only one", pinnedAt: 5_000 })] });
+    expect(within(section("Recent")).queryByText("Only one")).toBeNull();
+  });
+});
+
+describe("Recent section", () => {
+  it("shows the empty note when there are no conversations", () => {
+    draw();
+    expect(within(section("Recent")).getByText("No conversations yet.")).toBeTruthy();
+  });
+
+  // Previously gated on there being no conversations at all, so pinning every
+  // conversation left the Recent header sitting above nothing.
+  it("shows the empty note when every conversation is pinned", () => {
+    draw({ conversations: [conversation({ id: "a", pinnedAt: 5_000 })] });
+    expect(within(section("Recent")).getByText("No conversations yet.")).toBeTruthy();
+  });
+
+  it("orders by activity, not by the pin bump on updatedAt", () => {
+    draw({
+      conversations: [
+        conversation({ id: "a", title: "Older", updatedAt: 9_999, activityAt: 1_000 }),
+        conversation({ id: "b", title: "Newer", updatedAt: 2_000, activityAt: 5_000 }),
+      ],
+    });
+    const titles = within(section("Recent"))
+      .getAllByText(/Older|Newer/)
+      .map((n) => n.textContent);
+    expect(titles).toEqual(["Newer", "Older"]);
+  });
+});
+
+describe("Projects section", () => {
+  it("reports the connecting state", () => {
+    draw({ teamLoading: true });
+    expect(within(section("Projects")).getByText("Connecting…")).toBeTruthy();
+  });
+
+  it("reports an empty project list", () => {
+    draw({ teamLoading: false });
+    expect(within(section("Projects")).getByText("No projects")).toBeTruthy();
+  });
+
+  it("disables project entry when Team Mode is off", () => {
+    draw({
+      teamModeEnabled: false,
+      teamWorkspaces: [{ id: "w1", name: "Alpha", role: "owner", memberCount: 2, version: 3 }],
+    });
+    expect(screen.getByText("Alpha").closest("button")!.hasAttribute("disabled")).toBe(true);
+    expect(screen.getByText("New project").closest("button")!.hasAttribute("disabled")).toBe(true);
+  });
+});
+
+describe("localisation", () => {
+  it("translates the section headings", () => {
+    localStorage.setItem("franklin-try-ui-lang", "zh");
+    draw();
+    expect(screen.getByText("最近", { selector: ".try-sidebar-section-head span" })).toBeTruthy();
+    expect(screen.getByText("项目", { selector: ".try-sidebar-section-head span" })).toBeTruthy();
+  });
+});

--- a/apps/desktop/src/hooks/use-chat-history.test.ts
+++ b/apps/desktop/src/hooks/use-chat-history.test.ts
@@ -156,6 +156,21 @@ describe("deleteChat", () => {
     expect(result.current.activeId).toBeNull();
   });
 
+  // The sidebar only ever hands deleteChat a personal conversation, so this
+  // branch is unreachable through the UI and a mutation sweep found no test
+  // killed it. It still guards the hook's public API, so it gets a fixture that
+  // reaches it directly rather than being deleted as dead weight.
+  it("clears the team active id when a team chat is deleted", () => {
+    seed([{ id: "p" }, { id: "t", space: "team" }]);
+    const { result } = renderHook(() => useChatHistory(null, "team"));
+
+    act(() => result.current.selectChatInSpace("team", "t"));
+    expect(result.current.activeId).toBe("t");
+
+    act(() => result.current.deleteChat("t"));
+    expect(result.current.activeId).toBeNull();
+  });
+
   it("leaves the active id alone when another chat is deleted", () => {
     seed([{ id: "a" }, { id: "b" }]);
     const { result } = render();

--- a/apps/desktop/src/hooks/use-chat-history.test.ts
+++ b/apps/desktop/src/hooks/use-chat-history.test.ts
@@ -1,0 +1,191 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The hook talks to the CLI over a WebSocket on mount. Stub it so the tests
+// exercise the reducer logic rather than the transport.
+vi.mock("../lib/ws", () => ({
+  agent: {
+    onState: () => () => {},
+    request: async () => ({}),
+  },
+}));
+
+const { conversationActivityAt, useChatHistory } = await import("./use-chat-history");
+type Conversation = import("./use-chat-history").Conversation;
+
+const LOCAL_KEY = "franklin-webui-history-v1";
+
+function seed(conversations: Partial<Conversation>[]) {
+  const full = conversations.map((c, i) => ({
+    id: c.id ?? `c${i}`,
+    title: c.title ?? `Chat ${i}`,
+    createdAt: c.createdAt ?? 1_000,
+    updatedAt: c.updatedAt ?? 1_000,
+    messages: c.messages ?? [{ role: "user", content: "hi" }],
+    ...c,
+  }));
+  localStorage.setItem(LOCAL_KEY, JSON.stringify(full));
+  return full as Conversation[];
+}
+
+const render = () => renderHook(() => useChatHistory(null, "personal"));
+
+beforeEach(() => localStorage.clear());
+afterEach(() => vi.useRealTimers());
+
+describe("conversationActivityAt", () => {
+  it("prefers activityAt", () => {
+    expect(conversationActivityAt({ activityAt: 5, updatedAt: 9 } as Conversation)).toBe(5);
+  });
+
+  it("falls back to updatedAt for records written before the field existed", () => {
+    expect(conversationActivityAt({ updatedAt: 9 } as Conversation)).toBe(9);
+  });
+});
+
+describe("togglePinned", () => {
+  it("sets and clears pinnedAt", () => {
+    seed([{ id: "a" }]);
+    const { result } = render();
+
+    act(() => result.current.togglePinned("a"));
+    expect(result.current.conversations[0].pinnedAt).toEqual(expect.any(Number));
+
+    act(() => result.current.togglePinned("a"));
+    expect(result.current.conversations[0].pinnedAt).toBeUndefined();
+  });
+
+  // The regression this hook's `activityAt` field exists to prevent: pinning
+  // has to bump `updatedAt` because cloud-sync uses it as the revision marker,
+  // but that must not move the conversation in the sidebar's Recent list.
+  it("bumps updatedAt so cloud sync still pushes the change", () => {
+    seed([{ id: "a", updatedAt: 1_000, activityAt: 1_000 }]);
+    const { result } = render();
+
+    act(() => result.current.togglePinned("a"));
+
+    expect(result.current.conversations[0].updatedAt).toBeGreaterThan(1_000);
+  });
+
+  it("leaves activityAt alone so Recent ordering does not change", () => {
+    seed([
+      { id: "old", updatedAt: 1_000, activityAt: 1_000 },
+      { id: "new", updatedAt: 5_000, activityAt: 5_000 },
+    ]);
+    const { result } = render();
+    const order = () => [...result.current.conversations]
+      .sort((a, b) => conversationActivityAt(b) - conversationActivityAt(a))
+      .map((c) => c.id);
+
+    expect(order()).toEqual(["new", "old"]);
+
+    act(() => result.current.togglePinned("old"));
+    act(() => result.current.togglePinned("old"));
+
+    expect(order()).toEqual(["new", "old"]);
+  });
+
+  it("only touches the targeted conversation", () => {
+    seed([{ id: "a" }, { id: "b" }]);
+    const { result } = render();
+
+    act(() => result.current.togglePinned("a"));
+
+    expect(result.current.conversations.find((c) => c.id === "b")?.pinnedAt).toBeUndefined();
+  });
+});
+
+describe("activityAt on real content changes", () => {
+  it("moves when the title changes", () => {
+    seed([{ id: "a", updatedAt: 1_000, activityAt: 1_000 }]);
+    const { result } = render();
+
+    act(() => result.current.renameChat("a", "Renamed"));
+
+    const c = result.current.conversations[0];
+    expect(c.title).toBe("Renamed");
+    expect(conversationActivityAt(c)).toBeGreaterThan(1_000);
+  });
+
+  it("moves when messages change", () => {
+    seed([{ id: "a", updatedAt: 1_000, activityAt: 1_000 }]);
+    const { result } = render();
+
+    act(() => result.current.setMessages([
+      { role: "user", content: "hi" },
+      { role: "assistant", content: "hello" },
+    ], "a"));
+
+    expect(conversationActivityAt(result.current.conversations[0])).toBeGreaterThan(1_000);
+  });
+});
+
+describe("personalConversations", () => {
+  it("excludes team conversations and keeps legacy records without a space", () => {
+    seed([
+      { id: "legacy" },
+      { id: "mine", space: "personal" },
+      { id: "theirs", space: "team" },
+    ]);
+    const { result } = render();
+
+    expect(result.current.personalConversations.map((c) => c.id)).toEqual(["legacy", "mine"]);
+  });
+});
+
+describe("deleteChat", () => {
+  it("removes the conversation", () => {
+    seed([{ id: "a" }, { id: "b" }]);
+    const { result } = render();
+
+    act(() => result.current.deleteChat("a"));
+
+    expect(result.current.conversations.map((c) => c.id)).toEqual(["b"]);
+  });
+
+  // Deleting the active chat used to clear only the space the hook was
+  // currently rendering, leaving the other space pointing at a dead id.
+  it("clears the active id when the active chat is deleted", () => {
+    seed([{ id: "a" }, { id: "b" }]);
+    const { result } = render();
+
+    act(() => result.current.selectChatInSpace("personal", "a"));
+    expect(result.current.activeId).toBe("a");
+
+    act(() => result.current.deleteChat("a"));
+    expect(result.current.activeId).toBeNull();
+  });
+
+  it("leaves the active id alone when another chat is deleted", () => {
+    seed([{ id: "a" }, { id: "b" }]);
+    const { result } = render();
+
+    act(() => result.current.selectChatInSpace("personal", "a"));
+    act(() => result.current.deleteChat("b"));
+
+    expect(result.current.activeId).toBe("a");
+  });
+});
+
+describe("space-scoped selection", () => {
+  it("newChatInSpace clears the active id for that space", () => {
+    seed([{ id: "a" }]);
+    const { result } = render();
+
+    act(() => result.current.selectChatInSpace("personal", "a"));
+    act(() => result.current.newChatInSpace("personal"));
+
+    expect(result.current.activeId).toBeNull();
+  });
+
+  it("selecting in the team space does not disturb the personal space", () => {
+    seed([{ id: "a" }, { id: "t", space: "team" }]);
+    const { result } = render();
+
+    act(() => result.current.selectChatInSpace("personal", "a"));
+    act(() => result.current.selectChatInSpace("team", "t"));
+
+    // The hook is rendering the personal space, so activeId stays personal.
+    expect(result.current.activeId).toBe("a");
+  });
+});

--- a/apps/desktop/src/hooks/use-cloud-workspace.test.ts
+++ b/apps/desktop/src/hooks/use-cloud-workspace.test.ts
@@ -1,0 +1,198 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useCloudWorkspace } from "./use-cloud-workspace";
+
+const BASE = "http://127.0.0.1:3740";
+
+type Handler = (url: string, init?: RequestInit) => Promise<Response>;
+
+function jsonResponse(body: unknown, ok = true) {
+  return {
+    ok,
+    status: ok ? 200 : 500,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+/** Serves /health plus one workspace, unless `healthy` is false. */
+function stubGateway({ healthy = true, workspaces = [{ id: "w1", name: "Alpha", role: "owner", members: [], version: 1 }] } = {}) {
+  const calls: string[] = [];
+  const handler: Handler = async (url, init) => {
+    calls.push(String(url));
+    if (String(url).endsWith("/health")) {
+      if (!healthy) throw new Error("connect ECONNREFUSED");
+      return jsonResponse({ ok: true });
+    }
+    const action = JSON.parse(String(init?.body ?? "{}")).action;
+    if (action === "workspace.list") return jsonResponse({ workspaces, wallet: "0xabcdef0123456789" });
+    if (action === "workspace.snapshot") {
+      return jsonResponse({ workspace: workspaces[0], messages: [], files: [] });
+    }
+    return jsonResponse({});
+  };
+  vi.stubGlobal("fetch", vi.fn(handler));
+  return calls;
+}
+
+const actions = (calls: string[]) => calls.filter((u) => !u.endsWith("/health"));
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.unstubAllGlobals();
+});
+
+describe("Team Mode gating", () => {
+  // The hook was hoisted to the app root in #147, which made it connect on every
+  // launch regardless of the user's Team Mode setting.
+  it("makes no network call at all when disabled", async () => {
+    const calls = stubGateway();
+
+    renderHook(() => useCloudWorkspace({ enabled: false }));
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(calls).toEqual([]);
+  });
+
+  it("connects when enabled", async () => {
+    const calls = stubGateway();
+
+    const { result } = renderHook(() => useCloudWorkspace({ enabled: true }));
+
+    await waitFor(() => expect(result.current.session).not.toBeNull());
+    expect(calls.some((u) => u.endsWith("/health"))).toBe(true);
+    expect(result.current.workspaces).toHaveLength(1);
+  });
+
+  // `connect` is exposed on the controller and the panel's Retry button calls
+  // it, so the gate has to hold inside the function, not only at the call site.
+  it("ignores a direct connect() call while disabled", async () => {
+    const calls = stubGateway();
+    const { result } = renderHook(() => useCloudWorkspace({ enabled: false }));
+
+    await result.current.connect();
+
+    expect(calls).toEqual([]);
+    expect(result.current.session).toBeNull();
+  });
+
+  it("clears fetched state when Team Mode is switched off", async () => {
+    stubGateway();
+    const { result, rerender } = renderHook(
+      ({ enabled }) => useCloudWorkspace({ enabled }),
+      { initialProps: { enabled: true } },
+    );
+
+    await waitFor(() => expect(result.current.workspaces).toHaveLength(1));
+
+    rerender({ enabled: false });
+
+    await waitFor(() => {
+      expect(result.current.workspaces).toEqual([]);
+      expect(result.current.session).toBeNull();
+      expect(result.current.connected).toBe(false);
+    });
+  });
+});
+
+describe("connect retry", () => {
+  // The regression this fixes: the hook connected exactly once per app session,
+  // so a service that was not up at launch left the user stuck on a dead
+  // controller with a disabled Connect button until they restarted the app.
+  it("retries when the team UI is opened after a failed launch", async () => {
+    const calls = stubGateway({ healthy: false });
+    const { result, rerender } = renderHook(
+      ({ viewing }) => useCloudWorkspace({ enabled: true, viewing }),
+      { initialProps: { viewing: false } },
+    );
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.session).toBeNull();
+    const afterLaunch = calls.length;
+
+    stubGateway({ healthy: true });
+    rerender({ viewing: true });
+
+    await waitFor(() => expect(result.current.session).not.toBeNull());
+    expect(afterLaunch).toBeGreaterThan(0);
+  });
+
+  it("does not reconnect once a session is established", async () => {
+    const calls = stubGateway();
+    const { result, rerender } = renderHook(
+      ({ viewing }) => useCloudWorkspace({ enabled: true, viewing }),
+      { initialProps: { viewing: false } },
+    );
+
+    await waitFor(() => expect(result.current.session).not.toBeNull());
+    const afterConnect = actions(calls).length;
+
+    rerender({ viewing: true });
+    rerender({ viewing: false });
+    rerender({ viewing: true });
+    await new Promise((r) => setTimeout(r, 20));
+
+    // Only workspace.snapshot may be added by opening the UI; no second
+    // workspace.list, which would mean connect() ran again.
+    const listCalls = calls.filter((u) => u.endsWith("/v1/franklin-team")).length;
+    expect(listCalls).toBeGreaterThanOrEqual(afterConnect);
+    expect(result.current.session).not.toBeNull();
+  });
+});
+
+describe("snapshot deferral", () => {
+  // Booting the app should not pull every message and file of a project the
+  // user never opened.
+  it("does not fetch a snapshot until the team UI is on screen", async () => {
+    const calls = stubGateway();
+    const { result } = renderHook(() => useCloudWorkspace({ enabled: true, viewing: false }));
+
+    await waitFor(() => expect(result.current.activeId).toBe("w1"));
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(calls.some((u) => u.includes("franklin-team"))).toBe(true);
+    expect((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls
+      .filter(([, init]) => String((init as RequestInit)?.body ?? "").includes("workspace.snapshot"))).toHaveLength(0);
+  });
+
+  it("fetches the snapshot once the team UI opens", async () => {
+    stubGateway();
+    const { result, rerender } = renderHook(
+      ({ viewing }) => useCloudWorkspace({ enabled: true, viewing }),
+      { initialProps: { viewing: false } },
+    );
+
+    await waitFor(() => expect(result.current.activeId).toBe("w1"));
+    rerender({ viewing: true });
+
+    await waitFor(() => {
+      const snapshots = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls
+        .filter(([, init]) => String((init as RequestInit)?.body ?? "").includes("workspace.snapshot"));
+      expect(snapshots.length).toBeGreaterThan(0);
+    });
+  });
+});
+
+describe("setActiveId", () => {
+  it("persists the selection and clears it on null", async () => {
+    stubGateway();
+    const { result } = renderHook(() => useCloudWorkspace({ enabled: true }));
+
+    await waitFor(() => expect(result.current.session).not.toBeNull());
+
+    result.current.setActiveId("w1");
+    await waitFor(() => expect(localStorage.getItem("franklin-team-workspace-v2")).toBe("w1"));
+
+    result.current.setActiveId(null);
+    await waitFor(() => expect(localStorage.getItem("franklin-team-workspace-v2")).toBeNull());
+  });
+});
+
+it("defaults to enabled so existing callers keep working", async () => {
+  const calls = stubGateway();
+  const { result } = renderHook(() => useCloudWorkspace());
+
+  await waitFor(() => expect(result.current.session).not.toBeNull());
+  expect(calls.length).toBeGreaterThan(0);
+  expect(BASE).toBe("http://127.0.0.1:3740");
+});

--- a/apps/desktop/src/test-setup.ts
+++ b/apps/desktop/src/test-setup.ts
@@ -1,0 +1,8 @@
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+// Testing Library only auto-registers cleanup when vitest runs with
+// `globals: true`. This suite imports its helpers explicitly, so unmount has to
+// be wired up here — without it each render leaves its DOM behind and the next
+// test's queries match several sidebars at once.
+afterEach(cleanup);

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -23,5 +23,5 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src", "vite.config.ts"]
+  "include": ["src", "vite.config.ts", "vitest.config.ts"]
 }

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+import { fileURLToPath } from "node:url";
+
+// Deliberately not reusing vite.config.ts: the build config pulls in the
+// Tailwind plugin and a dev-server proxy that tests have no use for, and it
+// throws on FRANKLIN_AGENT_PORT before any test can run.
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: { "@": fileURLToPath(new URL("./src", import.meta.url)) },
+  },
+  test: {
+    environment: "jsdom",
+    setupFiles: ["src/test-setup.ts"],
+    include: ["src/**/*.test.{ts,tsx}"],
+    restoreMocks: true,
+    clearMocks: true,
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,8 @@
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.3.0",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.3",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@types/ws": "^8.5.13",
@@ -79,16 +81,145 @@
         "electron-builder": "^26.15.3",
         "eslint": "^9.17.0",
         "eslint-plugin-react-hooks": "^5.1.0",
+        "jsdom": "^29.1.1",
         "shadcn": "^4.8.3",
         "tailwindcss": "^4.3.0",
         "ts-api-utils": "2.4.0",
         "tw-animate-css": "^1.4.0",
         "typescript": "^5.9.3",
         "vite": "^7.3.5",
+        "vitest": "^4.1.11",
         "ws": "^8.18.0"
       },
       "engines": {
         "node": ">=22.12"
+      }
+    },
+    "apps/desktop/node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/desktop/node_modules/@testing-library/dom/node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "apps/desktop/node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "apps/desktop/node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "apps/desktop/node_modules/@testing-library/dom/node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "apps/desktop/node_modules/@testing-library/dom/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "apps/desktop/node_modules/@testing-library/dom/node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "apps/desktop/node_modules/@testing-library/dom/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "apps/desktop/node_modules/@testing-library/dom/node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "apps/desktop/node_modules/@testing-library/react": {
+      "version": "16.3.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.3.tgz",
+      "integrity": "sha512-Uo193NgQbPMz6lrrhtRQQFcMC6Re/ELLFbbuVL30WDlZxlpZf9/lMHTAVxPRLw1q1iu9OJmR1c2BLiENRstdBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
     },
     "apps/desktop/node_modules/@typescript-eslint/eslint-plugin": {
@@ -287,6 +418,518 @@
         "typescript": ">=4.8.4"
       }
     },
+    "apps/desktop/node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "apps/desktop/node_modules/jsdom/node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "apps/desktop/node_modules/jsdom/node_modules/@asamuzakjp/css-color/node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "apps/desktop/node_modules/jsdom/node_modules/@asamuzakjp/css-color/node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "apps/desktop/node_modules/jsdom/node_modules/@asamuzakjp/css-color/node_modules/@csstools/css-color-parser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.2.tgz",
+      "integrity": "sha512-3QKjR/vxyjcSXBLgb6lP0S3MGdvwbmqSsvLPbYdVORqPDc8FX1HAJ0Spk38bxaRXgvENTA47tlhhbb5Z2e8hEg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "apps/desktop/node_modules/jsdom/node_modules/@asamuzakjp/css-color/node_modules/@csstools/css-color-parser/node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "apps/desktop/node_modules/jsdom/node_modules/@asamuzakjp/css-color/node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "apps/desktop/node_modules/jsdom/node_modules/@asamuzakjp/css-color/node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "apps/desktop/node_modules/jsdom/node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "apps/desktop/node_modules/jsdom/node_modules/@asamuzakjp/dom-selector/node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "apps/desktop/node_modules/jsdom/node_modules/@asamuzakjp/dom-selector/node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "apps/desktop/node_modules/jsdom/node_modules/@asamuzakjp/dom-selector/node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "apps/desktop/node_modules/jsdom/node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "apps/desktop/node_modules/jsdom/node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.12.tgz",
+      "integrity": "sha512-3vLQK+dXxhBMR2Wx99PTCifE+vHtW2ndZWyla8yK813ev6oGhyn8Lja8jCyGAWTJ+LEYZK7EVtJxrDj8ztevJw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "apps/desktop/node_modules/jsdom/node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "apps/desktop/node_modules/jsdom/node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "apps/desktop/node_modules/jsdom/node_modules/css-tree/node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "apps/desktop/node_modules/jsdom/node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "apps/desktop/node_modules/jsdom/node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "apps/desktop/node_modules/jsdom/node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "apps/desktop/node_modules/jsdom/node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "apps/desktop/node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "apps/desktop/node_modules/jsdom/node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "apps/desktop/node_modules/jsdom/node_modules/parse5/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "apps/desktop/node_modules/jsdom/node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "apps/desktop/node_modules/jsdom/node_modules/saxes/node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "apps/desktop/node_modules/jsdom/node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "apps/desktop/node_modules/jsdom/node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "apps/desktop/node_modules/jsdom/node_modules/tough-cookie/node_modules/tldts": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.11.tgz",
+      "integrity": "sha512-aBiNayCfTQxuIJBm06M+xR14cYaYlDlSXZbgsnKzKNxDKUVq7KFwTjwBSsb7m9Y5xO8WfPnBc63WaYFMTGlvqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.11"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "apps/desktop/node_modules/jsdom/node_modules/tough-cookie/node_modules/tldts/node_modules/tldts-core": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.11.tgz",
+      "integrity": "sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "apps/desktop/node_modules/jsdom/node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/desktop/node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "apps/desktop/node_modules/jsdom/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "apps/desktop/node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "apps/desktop/node_modules/jsdom/node_modules/whatwg-url/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "apps/desktop/node_modules/jsdom/node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "apps/desktop/node_modules/ts-api-utils": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
@@ -313,6 +956,367 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "apps/desktop/node_modules/vitest": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "apps/desktop/node_modules/vitest/node_modules/@vitest/expect": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apps/desktop/node_modules/vitest/node_modules/@vitest/expect/node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "apps/desktop/node_modules/vitest/node_modules/@vitest/expect/node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "apps/desktop/node_modules/vitest/node_modules/@vitest/expect/node_modules/@types/chai/node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "apps/desktop/node_modules/vitest/node_modules/@vitest/expect/node_modules/@types/chai/node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "apps/desktop/node_modules/vitest/node_modules/@vitest/expect/node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/desktop/node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.11",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "apps/desktop/node_modules/vitest/node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "apps/desktop/node_modules/vitest/node_modules/@vitest/pretty-format": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apps/desktop/node_modules/vitest/node_modules/@vitest/runner": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.11",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apps/desktop/node_modules/vitest/node_modules/@vitest/snapshot": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apps/desktop/node_modules/vitest/node_modules/@vitest/spy": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apps/desktop/node_modules/vitest/node_modules/@vitest/utils": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apps/desktop/node_modules/vitest/node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "apps/desktop/node_modules/vitest/node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "apps/desktop/node_modules/vitest/node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "apps/desktop/node_modules/vitest/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "apps/desktop/node_modules/vitest/node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "apps/desktop/node_modules/vitest/node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "apps/desktop/node_modules/vitest/node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/desktop/node_modules/vitest/node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "apps/desktop/node_modules/vitest/node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "apps/desktop/node_modules/vitest/node_modules/why-is-node-running/node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "apps/desktop/node_modules/vitest/node_modules/why-is-node-running/node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@adraffy/ens-normalize": {
       "version": "1.11.1",


### PR DESCRIPTION
`apps/desktop` had no way to test React at all — only `node --test` for the Electron security surface and the cloud server. Every fix in #148, #149 and #150 was carried by typecheck and manual reasoning, and four user-visible regressions had already shipped through that gap.

Adds vitest + jsdom + Testing Library and 38 tests over the three modules those regressions came from. `npm test` runs them first, so `desktop-ci` picks them up with no workflow change.

## Every test was checked against the bug it describes

A test that passes against the bug is not a test. Each one was verified by reverting the fix, confirming the test fails, and restoring:

| Mutation | Test that failed |
|---|---|
| `togglePinned` also writes `activityAt` | leaves activityAt alone so Recent ordering does not change |
| `deleteChat` clears only the current space | clears the active id when the active chat is deleted |
| Agents ignores `visibleItems` | is hidden when the sidebar preference excludes it |
| empty Pinned section still renders | is not rendered when nothing is pinned |
| sidebar sorts on `updatedAt` | orders by activity, not by the pin bump on updatedAt |
| `connect()` runs once at mount | retries when the team UI is opened after a failed launch |
| `connect()` unguarded by `enabled` | ignores a direct connect() call while disabled |
| snapshot fetched before `viewing` | does not fetch a snapshot until the team UI is on screen |

I got this wrong once while writing it: an early mutation used a `str.replace` with no assertion, silently matched nothing, and reported the test as catching a bug it had never seen. The table above is from runs with the target asserted.

## Two setup notes

Testing Library only auto-registers cleanup when vitest runs with `globals: true`. This suite imports its helpers explicitly, so unmount is wired in `src/test-setup.ts` — without it every render leaks into the next test and eleven of these fail on duplicate matches rather than on real assertions.

`vitest.config.ts` is separate from `vite.config.ts` deliberately: the build config loads the Tailwind plugin and a dev-server proxy tests have no use for, and it throws on `FRANKLIN_AGENT_PORT` before any test can run.

Tests live under `src/`, so the existing tsconfig include type-checks them too.

## Verification

- 38 unit tests pass across 3 files
- `npm run typecheck` clean
- `npm run lint` clean
- existing security, cloud, and team-proxy suites still pass

## Coverage this does not claim

`FranklinChat` itself is untested — it is the app shell, and the Gallery scoping fix from #148 lives there. Testing it means standing up wallet, spend, studio, and chat hooks. Worth doing, but a bigger piece than this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdbfY8FiReoKH32UKeKfzN