### PR TITLE
fix(desktop): harden beta release runtime

### DIFF
--- a/apps/desktop/cloud-server/server.mjs
+++ b/apps/desktop/cloud-server/server.mjs
@@ -331,11 +331,9 @@ async function runtimeModules() {
 
 async function signingModules() {
   if (!signingModulesPromise) {
-    const packageRoot = path.dirname(path.dirname(runtimeEntry));
-    const modulesRoot = path.join(packageRoot, "node_modules", "@noble");
     signingModulesPromise = Promise.all([
-      import(pathToFileURL(path.join(modulesRoot, "curves", "secp256k1.js")).href),
-      import(pathToFileURL(path.join(modulesRoot, "hashes", "sha3.js")).href),
+      import("@noble/curves/secp256k1.js"),
+      import("@noble/hashes/sha3.js"),
     ]).then(([curves, hashes]) => ({ secp256k1: curves.secp256k1, keccak256: hashes.keccak_256 }));
   }
   return signingModulesPromise;
@@ -343,13 +341,11 @@ async function signingModules() {
 
 async function localWallet() {
   const { secp256k1, keccak256 } = await signingModules();
-  const walletDir = path.join(os.homedir(), ".blockrun");
-  const walletFile = path.join(walletDir, ".session");
-  const legacyFile = path.join(walletDir, "wallet.key");
-  let privateKey = process.env.BLOCKRUN_WALLET_KEY || process.env.BASE_CHAIN_WALLET_KEY || "";
-  if (!privateKey) privateKey = await fsp.readFile(walletFile, "utf8").then((value) => value.trim()).catch(() => "");
-  if (!privateKey) privateKey = await fsp.readFile(legacyFile, "utf8").then((value) => value.trim()).catch(() => "");
-  if (!privateKey) throw new Error("No local Franklin wallet is configured; create one in Franklin before connecting Team Cloud");
+  // Team Cloud uses an EVM SIWE identity even when the active payment chain is
+  // Solana. The SDK creates the same local Base wallet Franklin uses elsewhere
+  // without changing the user's selected payment chain.
+  const { getOrCreateWallet } = await import("@blockrun/llm");
+  const { privateKey } = getOrCreateWallet();
   const privateBytes = Buffer.from(privateKey.replace(/^0x/, ""), "hex");
   if (privateBytes.length !== 32) throw new Error("Franklin wallet key is invalid");
   const publicKey = secp256k1.getPublicKey(privateBytes, false);

--- a/apps/desktop/cloud-server/team-proxy.test.mjs
+++ b/apps/desktop/cloud-server/team-proxy.test.mjs
@@ -1,10 +1,13 @@
 import assert from "node:assert/strict";
+import fsp from "node:fs/promises";
 import http from "node:http";
+import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
+const walletHome = await fsp.mkdtemp(path.join(os.tmpdir(), ".franklin-team-wallet-"));
 const token = "desktop-team-test-token";
 const workspace = {
   id: "tw_test", name: "Proxy Test", createdAt: new Date().toISOString(), version: 1,
@@ -59,9 +62,11 @@ const child = spawn(process.execPath, [path.join(here, "server.mjs")], {
     FRANKLIN_CLOUD_TOKEN: token,
     FRANKLIN_TEAM_CLOUD_URL: `http://127.0.0.1:${remotePort}`,
     FRANKLIN_TEAM_FAKE_AGENT: "1",
-    BLOCKRUN_WALLET_KEY: `0x${"11".repeat(32)}`,
+    HOME: walletHome,
+    BLOCKRUN_HOME: walletHome,
     FRANKLIN_RUNTIME_ENTRY: process.env.FRANKLIN_TEST_RUNTIME_ENTRY
-      || path.join(here, "..", "..", "..", "dist", "index.js"),
+      // Mirror the packaged layout: the runtime has no sibling node_modules.
+      || path.join(here, ".packaged-layout", "franklin-agent", "dist", "index.js"),
   },
   stdio: ["ignore", "pipe", "pipe", "ipc"],
 });
@@ -112,4 +117,5 @@ try {
 } finally {
   child.kill("SIGTERM");
   await new Promise((resolve) => mockCloud.close(resolve));
+  await fsp.rm(walletHome, { recursive: true, force: true });
 }

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -25,6 +25,7 @@ const {
   sameOriginUrl,
   trustedRendererUrl,
 } = require("./security.cjs");
+const { createStudioRuntimeManager } = require("./studio-runtime.cjs");
 
 // Is something already listening on a local port? Used so we don't double-spawn
 // Franklin Canvas (a second `npm start` would hit EADDRINUSE on :3100 and, per
@@ -198,6 +199,8 @@ if (hasSingleInstanceLock) {
 const STUDIO_RUNTIME_SPECS = {
   codex: {
     command: "codex",
+    args: ["app-server", "--stdio"],
+    lifecycleSupported: true,
     candidates: [
       process.env.CODEX_PATH,
       "/Applications/ChatGPT.app/Contents/Resources/codex",
@@ -213,6 +216,7 @@ const STUDIO_RUNTIME_SPECS = {
   hermes: { command: "hermes", candidates: [process.env.HERMES_PATH] },
   deepseek: { command: "dsh", candidates: [process.env.DSH_PATH] },
 };
+const studioRuntimes = createStudioRuntimeManager();
 
 function execFileText(file, args, timeout = 5000) {
   return new Promise((resolve) => {
@@ -240,17 +244,19 @@ async function resolveStudioRuntime(id) {
 }
 
 async function inspectStudioRuntime(id) {
+  const spec = STUDIO_RUNTIME_SPECS[id];
+  if (!spec) return { id, available: false, running: false };
   const executable = await resolveStudioRuntime(id);
   if (!executable) return { id, available: false, running: false };
   const versionResult = await execFileText(executable, ["--version"], 5000);
-  const running = false;
+  const running = studioRuntimes.isRunning(id);
   return {
     id,
     available: true,
     running,
     path: executable,
     version: versionResult.output.split("\n")[0] || "Detected",
-    lifecycleSupported: false,
+    lifecycleSupported: spec.lifecycleSupported === true,
   };
 }
 
@@ -260,11 +266,34 @@ async function scanStudioRuntimes() {
 
 async function startStudioRuntime(id) {
   const detected = await inspectStudioRuntime(id);
-  return { ok: false, running: false, ...detected, error: "Runtime detected, but the Desktop protocol adapter is not implemented yet." };
+  const spec = STUDIO_RUNTIME_SPECS[id];
+  if (!detected.available) return { ok: false, ...detected, error: "CLI not found." };
+  if (!spec?.lifecycleSupported) {
+    return { ok: false, ...detected, error: "Runtime detected, but the Desktop protocol adapter is not implemented yet." };
+  }
+  const workDir = process.env.FRANKLIN_WORK_DIR
+    ? path.resolve(process.env.FRANKLIN_WORK_DIR)
+    : path.join(app.getPath("documents"), "Franklin");
+  fs.mkdirSync(workDir, { recursive: true, mode: 0o700 });
+  const result = await studioRuntimes.start({
+    id,
+    executable: detected.path,
+    args: spec.args,
+    cwd: workDir,
+    env: {
+      ...backendBaseEnvironment(),
+      ...(process.env.CODEX_HOME ? { CODEX_HOME: process.env.CODEX_HOME } : {}),
+    },
+  });
+  return { ...detected, ...result, endpoint: result.running ? "stdio" : undefined };
 }
 
 async function stopStudioRuntime(id) {
-  return { ok: false, running: false, error: `The ${id} Desktop protocol adapter is not implemented yet.` };
+  const spec = STUDIO_RUNTIME_SPECS[id];
+  if (!spec?.lifecycleSupported) {
+    return { ok: false, running: false, error: `The ${id} Desktop protocol adapter is not implemented yet.` };
+  }
+  return studioRuntimes.stop(id);
 }
 
 // Auto-start Franklin Canvas (its own backend :3100 + Vite UI :5173) so the
@@ -637,6 +666,7 @@ app.on("window-all-closed", () => {
 app.on("before-quit", () => { quitting = true; });
 
 app.on("quit", () => {
+  studioRuntimes.stopAll();
   if (backend) backend.kill();
   if (cloudBackend) cloudBackend.kill();
   if (canvas) canvas.kill();

--- a/apps/desktop/electron/studio-runtime.cjs
+++ b/apps/desktop/electron/studio-runtime.cjs
@@ -1,0 +1,91 @@
+const { spawn } = require("node:child_process");
+
+function createStudioRuntimeManager({ spawnProcess = spawn, readyDelayMs = 150 } = {}) {
+  const processes = new Map();
+
+  function isRunning(id) {
+    const child = processes.get(id);
+    return Boolean(child && child.exitCode === null && !child.killed);
+  }
+
+  async function start({ id, executable, args, cwd, env }) {
+    if (isRunning(id)) return { ok: true, running: true };
+
+    let child;
+    try {
+      child = spawnProcess(executable, args, {
+        cwd,
+        env,
+        stdio: ["pipe", "pipe", "pipe"],
+        windowsHide: true,
+      });
+    } catch (error) {
+      return { ok: false, running: false, error: String(error?.message || error) };
+    }
+
+    processes.set(id, child);
+    child.stdout?.resume();
+    let stderr = "";
+    child.stderr?.on("data", (chunk) => {
+      stderr = `${stderr}${String(chunk)}`.slice(-2_000);
+    });
+    child.once("exit", () => {
+      if (processes.get(id) === child) processes.delete(id);
+    });
+
+    return new Promise((resolve) => {
+      let settled = false;
+      const finish = (value) => {
+        if (settled) return;
+        settled = true;
+        resolve(value);
+      };
+      child.once("error", (error) => {
+        if (processes.get(id) === child) processes.delete(id);
+        finish({ ok: false, running: false, error: String(error?.message || error) });
+      });
+      child.once("exit", (code) => {
+        finish({
+          ok: false,
+          running: false,
+          error: stderr.trim() || `Runtime exited during startup (${code})`,
+        });
+      });
+      child.once("spawn", () => {
+        setTimeout(() => {
+          if (child.exitCode === null && !child.killed) finish({ ok: true, running: true });
+        }, readyDelayMs);
+      });
+    });
+  }
+
+  async function stop(id) {
+    const child = processes.get(id);
+    if (!child || child.exitCode !== null) {
+      processes.delete(id);
+      return { ok: true, running: false };
+    }
+    await new Promise((resolve) => {
+      const timer = setTimeout(resolve, 2_000);
+      child.once("exit", () => {
+        clearTimeout(timer);
+        resolve();
+      });
+      child.kill();
+    });
+    if (child.exitCode === null) child.kill("SIGKILL");
+    processes.delete(id);
+    return { ok: true, running: false };
+  }
+
+  function stopAll() {
+    for (const child of processes.values()) {
+      if (child.exitCode === null) child.kill();
+    }
+    processes.clear();
+  }
+
+  return { isRunning, start, stop, stopAll };
+}
+
+module.exports = { createStudioRuntimeManager };

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blockrun/franklin-desktop",
   "version": "0.2.0-beta.2",
+  "author": "BlockRun <hello@blockrun.ai>",
   "description": "Franklin Desktop — native desktop app for the Franklin agent (Electron). Same agent, wallet and tools as the CLI, in a polished window.",
   "license": "Apache-2.0",
   "type": "module",
@@ -35,7 +36,10 @@
   },
   "dependencies": {
     "@blockrun/franklin": "*",
+    "@blockrun/llm": "^3.13.1",
     "@fontsource/poppins": "^5.2.7",
+    "@noble/curves": "^1.9.7",
+    "@noble/hashes": "^1.8.0",
     "html-to-image": "^1.11.13",
     "https-proxy-agent": "^9.1.0",
     "lucide-react": "^0.469.0",
@@ -85,7 +89,11 @@
       "cloud-server/server.mjs",
       "package.json",
       "!node_modules/@blockrun/franklin",
-      "!node_modules/@blockrun/franklin/**"
+      "!node_modules/@blockrun/franklin/**",
+      "!node_modules/@colbymchenry/codegraph",
+      "!node_modules/@colbymchenry/codegraph/**",
+      "!node_modules/@colbymchenry/codegraph-*",
+      "!node_modules/@colbymchenry/codegraph-*/**"
     ],
     "asar": true,
     "mac": {

--- a/apps/desktop/test/studio-runtime.test.cjs
+++ b/apps/desktop/test/studio-runtime.test.cjs
@@ -1,0 +1,35 @@
+const assert = require("node:assert/strict");
+const { test } = require("node:test");
+const { createStudioRuntimeManager } = require("../electron/studio-runtime.cjs");
+
+test("studio runtime manager starts, reuses, and stops a long-running adapter", async () => {
+  const manager = createStudioRuntimeManager({ readyDelayMs: 20 });
+  const input = {
+    id: "codex",
+    executable: process.execPath,
+    args: ["-e", "setInterval(() => {}, 1000)"],
+    cwd: process.cwd(),
+    env: process.env,
+  };
+
+  const started = await manager.start(input);
+  assert.deepEqual(started, { ok: true, running: true });
+  assert.equal(manager.isRunning("codex"), true);
+  assert.deepEqual(await manager.start(input), { ok: true, running: true });
+  assert.deepEqual(await manager.stop("codex"), { ok: true, running: false });
+  assert.equal(manager.isRunning("codex"), false);
+});
+
+test("studio runtime manager reports startup failures", async () => {
+  const manager = createStudioRuntimeManager({ readyDelayMs: 20 });
+  const result = await manager.start({
+    id: "codex",
+    executable: `${process.execPath}.missing`,
+    args: [],
+    cwd: process.cwd(),
+    env: process.env,
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.running, false);
+  assert.match(result.error, /ENOENT|spawn/);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,10 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@blockrun/franklin": "*",
+        "@blockrun/llm": "^3.13.1",
         "@fontsource/poppins": "^5.2.7",
+        "@noble/curves": "^1.9.7",
+        "@noble/hashes": "^1.8.0",
         "html-to-image": "^1.11.13",
         "https-proxy-agent": "^9.1.0",
         "lucide-react": "^0.469.0",
@@ -5119,13 +5122,40 @@
       }
     },
     "node_modules/@polymarket/builder-relayer-client/node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.20.0.tgz",
+      "integrity": "sha512-r8aOh8j9cGKpgQAqpzrUHnSIc6a59Y3Xf/cv8sy1DrHCkZHzQGEuoq1tARk6qSyDdtQGSDgpb9kFlruzPvrgwg==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.6",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/@polymarket/builder-relayer-client/node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@polymarket/builder-relayer-client/node_modules/axios/node_modules/https-proxy-agent/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/@polymarket/builder-relayer-client/node_modules/typescript": {
@@ -7775,6 +7805,22 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/qs": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/boolean": {
@@ -10799,6 +10845,22 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/express/node_modules/qs": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -12327,21 +12389,6 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
-    },
-    "node_modules/jayson/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
     },
     "node_modules/jayson/node_modules/ws": {
       "version": "7.5.13",
@@ -15361,22 +15408,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "es-define-property": "^1.0.1",
-        "side-channel": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12390,6 +12390,21 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
     },
+    "node_modules/jayson/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/jayson/node_modules/ws": {
       "version": "7.5.13",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",

--- a/package.json
+++ b/package.json
@@ -108,6 +108,10 @@
   },
   "overrides": {
     "ws@>=8.0.0 <=8.20.1": "^8.21.1",
-    "@polymarket/builder-signing-sdk": "1.0.0"
+    "@polymarket/builder-signing-sdk": "1.0.0",
+    "@polymarket/builder-relayer-client": {
+      "axios": "^1.18.1"
+    },
+    "qs": "^6.16.0"
   }
 }


### PR DESCRIPTION
## Summary
- create/reuse a local Base identity wallet for Team Cloud SIWE on fresh Solana-first installs
- fix packaged noble module resolution and add the required runtime dependencies
- add managed Codex app-server lifecycle support to Agent Studio
- exclude the optional CodeGraph native runtime from the desktop package
- update vulnerable axios and qs transitive dependencies

## Validation
- Franklin root suite: 688/688 passing
- Desktop: 39 UI tests, 6 security/runtime tests, Cloud integration, and Team/SIWE integration passing
- Desktop typecheck and lint passing
- packaged app smoke-tested: Codex detected, started over stdio, and stopped
- macOS arm64 DMG built and verified with hdiutil

Ready for review. macOS signing/notarization is intentionally out of scope.