### PR TITLE
chore(desktop): prepare 0.2.0 beta 3

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockrun/franklin-desktop",
-  "version": "0.2.0-beta.2",
+  "version": "0.2.0-beta.3",
   "author": "BlockRun <hello@blockrun.ai>",
   "description": "Franklin Desktop — native desktop app for the Franklin agent (Electron). Same agent, wallet and tools as the CLI, in a polished window.",
   "license": "Apache-2.0",

--- a/apps/desktop/release-notes/0.2.0-beta.3.md
+++ b/apps/desktop/release-notes/0.2.0-beta.3.md
@@ -1,0 +1,17 @@
+Franklin Desktop Beta for macOS Apple Silicon and Windows x64.
+
+## What's improved
+
+- **Codex Agent import now starts a real runtime.** Agent Studio detects a local Codex CLI and manages its `app-server` lifecycle over stdio, including start and stop state.
+- **Team Cloud works on fresh Solana-first installs.** Franklin creates and reuses a local Base identity wallet for SIWE without changing the selected payment chain.
+- **Packaged Team login no longer loses its signing modules.** Noble curve and hash dependencies resolve correctly from the installed app.
+- **The installer is leaner.** The optional CodeGraph native runtime is no longer bundled into Desktop; Franklin continues cleanly without it.
+- **Dependency fixes are included.** The affected Axios and `qs` dependency paths are updated, and the lockfile is reproducible with CI's npm version.
+
+## Downloads
+
+- `Franklin-0.2.0-beta.3-arm64.dmg` for Apple Silicon Macs
+- `Franklin.Setup.0.2.0-beta.3.exe` for Windows x64
+- `SHA256SUMS.txt` for download verification
+
+These beta installers are currently unsigned. On first launch, macOS or Windows may ask you to confirm that you want to open the app.

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
     },
     "apps/desktop": {
       "name": "@blockrun/franklin-desktop",
-      "version": "0.2.0-beta.2",
+      "version": "0.2.0-beta.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@blockrun/franklin": "*",


### PR DESCRIPTION
## Summary
- bump Franklin Desktop from 0.2.0-beta.2 to 0.2.0-beta.3
- add release notes for the tested runtime, Team Cloud, packaging, and dependency fixes merged in #153
- preserve unsigned beta status as requested

## Validation
- npm 10 clean-install dry run passes
- #153 passed Node 20/22, macOS, Windows, and Desktop checks

Ready for review.